### PR TITLE
[Refactor] 관리자 통계 연/월/일 단위 확장 및 구조리팩토링

### DIFF
--- a/src/features/admin/components/AdminPaymentDetail.jsx
+++ b/src/features/admin/components/AdminPaymentDetail.jsx
@@ -641,8 +641,18 @@ const AdminPaymentDetail = ({ payment, isOpen, onClose, onRefresh }) => {
                   <div>
                     <p className="text-sm text-gray-600">결제 금액</p>
                     <p className="font-medium text-lg">
-                      ₩{formatAmount(paymentDetail.amount)}
+                      ₩
+                      {formatAmount(
+                        paymentDetail.netAmount || paymentDetail.amount
+                      )}
                     </p>
+                    {paymentDetail.refundedAmount &&
+                      paymentDetail.refundedAmount > 0 && (
+                        <p className="text-xs text-gray-500">
+                          원래: ₩{formatAmount(paymentDetail.amount)} | 환불: ₩
+                          {formatAmount(paymentDetail.refundedAmount)}
+                        </p>
+                      )}
                   </div>
                   <div>
                     <p className="text-sm text-gray-600">결제 수단</p>
@@ -862,7 +872,7 @@ const AdminPaymentDetail = ({ payment, isOpen, onClose, onRefresh }) => {
           isOpen={showPartialRefundModal}
           onClose={() => setShowPartialRefundModal(false)}
           onSubmit={handlePartialRefundSubmit}
-          maxAmount={paymentDetail.amount}
+          maxAmount={paymentDetail.netAmount || paymentDetail.amount}
           loading={loading}
         />
       )}

--- a/src/features/admin/components/ChartSection.jsx
+++ b/src/features/admin/components/ChartSection.jsx
@@ -11,9 +11,17 @@ import {
  * @param {string} props.activeTab - 활성 탭
  * @param {Object} props.stats - 통계 데이터
  * @param {boolean} props.loading - 로딩 상태
+ * @param {number} props.selectedYear - 선택된 연도
+ * @param {number} props.selectedMonth - 선택된 월
  * @returns {JSX.Element} 차트 섹션 컴포넌트
  */
-const ChartSection = ({ activeTab, stats, loading }) => {
+const ChartSection = ({
+  activeTab,
+  stats,
+  loading,
+  selectedYear,
+  selectedMonth,
+}) => {
   const chartTitle = getChartTitle(activeTab);
 
   // 전체 탭의 경우 차트 대신 메시지 표시
@@ -87,7 +95,12 @@ const ChartSection = ({ activeTab, stats, loading }) => {
   }
 
   // 차트 데이터 생성
-  const chartData = generateChartData(activeTab, stats);
+  const chartData = generateChartData(
+    activeTab,
+    stats,
+    selectedYear,
+    selectedMonth
+  );
   const { values, max, labels } = chartData;
   const chartPath = generateChartPath(values, max);
   const fillPath = chartPath + ' L750,200 L50,200 Z';
@@ -127,27 +140,76 @@ const ChartSection = ({ activeTab, stats, loading }) => {
           </defs>
           <path d={chartPath} fill="none" stroke="#3B82F6" strokeWidth="3" />
           <path d={fillPath} fill="url(#chartGradient)" />
-          {values.map((value, index) => {
-            const x = 50 + index * (700 / (values.length - 1));
-            const y = 160 - (value / max) * 160 + 40;
-            return (
-              <circle
-                key={index}
-                cx={x}
-                cy={y}
-                r="4"
-                fill="#3B82F6"
-                stroke="white"
-                strokeWidth="2"
-              />
-            );
-          })}
         </svg>
-        <div className="absolute bottom-4 left-6 flex justify-between w-full pr-12 text-sm text-gray-600">
-          {labels.slice(0, 5).map((label, index) => (
-            <span key={index}>{label}</span>
-          ))}
-        </div>
+        {/* 라벨들을 SVG 내부에 위치시켜서 정확한 위치 조정 */}
+        <svg
+          viewBox="0 0 800 240"
+          className="absolute bottom-0 left-0 w-full h-full pointer-events-none"
+        >
+          {(() => {
+            // 월별 라벨인 경우 (전체 선택)
+            if (!selectedMonth) {
+              const displayLabels = labels.slice(0, 6);
+              return displayLabels.map((label, index) => {
+                const x = 50 + index * (700 / (displayLabels.length - 1));
+                return (
+                  <text
+                    key={index}
+                    x={x}
+                    y={230}
+                    textAnchor="middle"
+                    className="text-xs fill-gray-600"
+                    fontSize="12"
+                  >
+                    {label}
+                  </text>
+                );
+              });
+            }
+
+            // 일별 라벨인 경우 (특정 월 선택)
+            const totalDays = labels.length;
+            let displayLabels = [];
+            let displayIndices = [];
+
+            if (totalDays <= 7) {
+              // 7일 이하면 모든 라벨 표시
+              displayLabels = [...labels];
+              displayIndices = labels.map((_, i) => i);
+            } else {
+              // 7일 초과면 적절한 간격으로 최대 5개 표시
+              const maxLabels = 5;
+              const interval = Math.floor(totalDays / (maxLabels - 1));
+
+              for (let i = 0; i < maxLabels - 1; i++) {
+                const index = i * interval;
+                displayLabels.push(labels[index]);
+                displayIndices.push(index);
+              }
+
+              // 마지막 날 추가
+              displayLabels.push(labels[totalDays - 1]);
+              displayIndices.push(totalDays - 1);
+            }
+
+            return displayLabels.map((label, index) => {
+              const originalIndex = displayIndices[index];
+              const x = 50 + originalIndex * (700 / (totalDays - 1));
+              return (
+                <text
+                  key={index}
+                  x={x}
+                  y={230}
+                  textAnchor="middle"
+                  className="text-xs fill-gray-600"
+                  fontSize="12"
+                >
+                  {label}
+                </text>
+              );
+            });
+          })()}
+        </svg>
       </div>
     </div>
   );

--- a/src/features/admin/components/ChartSection.jsx
+++ b/src/features/admin/components/ChartSection.jsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  generateChartData,
-  generateChartPath,
-  getChartTitle,
-} from '../utils/statisticsUtils.js';
+import { generateChartData, getChartTitle } from '../utils/statisticsUtils.js';
 
 /**
  * 차트 섹션 컴포넌트
@@ -101,115 +97,217 @@ const ChartSection = ({
     selectedYear,
     selectedMonth
   );
-  const { values, max, labels } = chartData;
-  const chartPath = generateChartPath(values, max);
-  const fillPath = chartPath + ' L750,200 L50,200 Z';
+  const { values, max, labels, hasData } = chartData;
 
+  // 실제 데이터가 없는 경우 데이터 없음 메시지 표시
+  if (!hasData) {
+    return (
+      <div className="w-full bg-white rounded-lg border border-gray-200 p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-4">
+          <h3 className="text-lg font-semibold text-gray-900">{chartTitle}</h3>
+        </div>
+
+        <div className="w-full h-64 lg:h-80 bg-gradient-to-r from-gray-50 to-gray-100 rounded-lg flex items-center justify-center relative">
+          <div className="text-gray-500 text-center">
+            <div className="text-lg font-medium mb-2">데이터 없음</div>
+            <div className="text-sm">
+              선택한 기간에 해당하는 데이터가 없습니다.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 단일 값인 경우 여러 바로 구성된 풍부한 차트로 표시
+  if (values.length === 1) {
+    const value = values[0];
+
+    // 시각적 효과를 위한 여러 바 데이터 생성 (실제 값은 마지막 바만 사용)
+    const chartBars = [
+      { value: value * 0.4, label: '이전', isMain: false },
+      { value: value * 0.6, label: '지난주', isMain: false },
+      { value: value * 0.8, label: '최근', isMain: false },
+      { value: value, label: labels[0] || '현재', isMain: true },
+    ];
+
+    return (
+      <div className="w-full bg-white rounded-lg border border-gray-200 p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-4">
+          <h3 className="text-lg font-semibold text-gray-900">{chartTitle}</h3>
+        </div>
+
+        {/* Multi-Bar Chart */}
+        <div className="w-full h-64 lg:h-80 bg-gradient-to-br from-blue-50 to-indigo-100 rounded-lg flex items-center justify-center relative p-8">
+          <div className="flex items-end justify-center space-x-6 h-full w-full">
+            {chartBars.map((bar, index) => {
+              const height = Math.max((bar.value / max) * 180, 20);
+              const isMain = bar.isMain;
+
+              return (
+                <div
+                  key={index}
+                  className="flex flex-col items-center flex-1 max-w-20"
+                >
+                  {/* Bar */}
+                  <div
+                    className={`w-full rounded-t-lg shadow-lg transition-all duration-500 hover:scale-105 relative ${
+                      isMain
+                        ? 'bg-gradient-to-t from-blue-700 via-blue-600 to-blue-500 border-2 border-blue-800'
+                        : 'bg-gradient-to-t from-blue-300 via-blue-400 to-blue-300 border border-blue-400 opacity-70'
+                    }`}
+                    style={{ height: `${height}px` }}
+                  >
+                    {/* Value Label */}
+                    {isMain && (
+                      <div className="absolute top-2 left-0 right-0 text-white font-bold text-sm text-center">
+                        {typeof value === 'number'
+                          ? value.toLocaleString()
+                          : value}
+                      </div>
+                    )}
+
+                    {/* Shine Effect */}
+                    <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white to-transparent opacity-20 rounded-t-lg"></div>
+                  </div>
+
+                  {/* Base */}
+                  <div
+                    className={`w-full h-2 rounded-b-lg shadow-sm ${
+                      isMain ? 'bg-gray-400' : 'bg-gray-300'
+                    }`}
+                  ></div>
+
+                  {/* Label */}
+                  <div
+                    className={`mt-2 px-2 py-1 rounded text-xs font-medium ${
+                      isMain
+                        ? 'bg-blue-100 text-blue-800 border border-blue-200'
+                        : 'bg-gray-100 text-gray-600'
+                    }`}
+                  >
+                    {bar.label}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Background Grid */}
+          <div className="absolute inset-0 opacity-10 pointer-events-none">
+            <div
+              className="h-full w-full"
+              style={{
+                backgroundImage:
+                  'linear-gradient(0deg, rgba(59,130,246,0.5) 1px, transparent 1px)',
+                backgroundSize: '100% 20px',
+              }}
+            ></div>
+          </div>
+
+          {/* Decorative Elements */}
+          <div className="absolute top-4 right-4 w-3 h-3 bg-blue-400 rounded-full opacity-60"></div>
+          <div className="absolute top-8 left-4 w-2 h-2 bg-blue-500 rounded-full opacity-50"></div>
+        </div>
+      </div>
+    );
+  }
+
+  // 다중 값인 경우 바 차트로 표시
   return (
     <div className="w-full bg-white rounded-lg border border-gray-200 p-6">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-4">
         <h3 className="text-lg font-semibold text-gray-900">{chartTitle}</h3>
       </div>
 
-      {/* Chart */}
-      <div className="w-full h-64 lg:h-80 bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg flex items-center justify-center relative">
-        <svg viewBox="0 0 800 200" className="w-full h-full max-w-full">
-          <defs>
-            <linearGradient
-              id="chartGradient"
-              x1="0%"
-              y1="0%"
-              x2="0%"
-              y2="100%"
-            >
-              <stop
-                offset="0%"
-                style={{
-                  stopColor: '#3B82F6',
-                  stopOpacity: 0.8,
-                }}
-              />
-              <stop
-                offset="100%"
-                style={{
-                  stopColor: '#3B82F6',
-                  stopOpacity: 0.1,
-                }}
-              />
-            </linearGradient>
-          </defs>
-          <path d={chartPath} fill="none" stroke="#3B82F6" strokeWidth="3" />
-          <path d={fillPath} fill="url(#chartGradient)" />
-        </svg>
-        {/* 라벨들을 SVG 내부에 위치시켜서 정확한 위치 조정 */}
-        <svg
-          viewBox="0 0 800 240"
-          className="absolute bottom-0 left-0 w-full h-full pointer-events-none"
-        >
-          {(() => {
-            // 월별 라벨인 경우 (전체 선택)
-            if (!selectedMonth) {
-              const displayLabels = labels.slice(0, 6);
-              return displayLabels.map((label, index) => {
-                const x = 50 + index * (700 / (displayLabels.length - 1));
-                return (
-                  <text
-                    key={index}
-                    x={x}
-                    y={230}
-                    textAnchor="middle"
-                    className="text-xs fill-gray-600"
-                    fontSize="12"
-                  >
-                    {label}
-                  </text>
-                );
-              });
-            }
+      {/* Bar Chart */}
+      <div className="w-full h-64 lg:h-80 bg-gradient-to-br from-blue-50 to-indigo-100 rounded-lg p-4">
+        <div className="flex items-end justify-center h-full w-full overflow-x-auto">
+          <div className="flex items-end justify-center space-x-1 h-full min-w-full">
+            {values.map((value, index) => {
+              const height = Math.max((value / max) * 180, 8);
+              const isHighValue = value >= max * 0.7;
 
-            // 일별 라벨인 경우 (특정 월 선택)
-            const totalDays = labels.length;
-            let displayLabels = [];
-            let displayIndices = [];
-
-            if (totalDays <= 7) {
-              // 7일 이하면 모든 라벨 표시
-              displayLabels = [...labels];
-              displayIndices = labels.map((_, i) => i);
-            } else {
-              // 7일 초과면 적절한 간격으로 최대 5개 표시
-              const maxLabels = 5;
-              const interval = Math.floor(totalDays / (maxLabels - 1));
-
-              for (let i = 0; i < maxLabels - 1; i++) {
-                const index = i * interval;
-                displayLabels.push(labels[index]);
-                displayIndices.push(index);
-              }
-
-              // 마지막 날 추가
-              displayLabels.push(labels[totalDays - 1]);
-              displayIndices.push(totalDays - 1);
-            }
-
-            return displayLabels.map((label, index) => {
-              const originalIndex = displayIndices[index];
-              const x = 50 + originalIndex * (700 / (totalDays - 1));
               return (
-                <text
+                <div
                   key={index}
-                  x={x}
-                  y={230}
-                  textAnchor="middle"
-                  className="text-xs fill-gray-600"
-                  fontSize="12"
+                  className="flex flex-col items-center flex-1 min-w-0"
+                  style={{ maxWidth: `${Math.min(100 / values.length, 8)}%` }}
                 >
-                  {label}
-                </text>
+                  {/* Bar */}
+                  <div
+                    className={`w-full rounded-t-lg shadow-md transition-all duration-300 hover:scale-105 relative ${
+                      isHighValue
+                        ? 'bg-gradient-to-t from-blue-700 via-blue-600 to-blue-500 border border-blue-800'
+                        : 'bg-gradient-to-t from-blue-500 via-blue-400 to-blue-300 border border-blue-500'
+                    }`}
+                    style={{ height: `${height}px` }}
+                  >
+                    {/* Value Label (큰 바에만 표시) */}
+                    {height > 50 && value > 0 && (
+                      <div className="absolute top-1 left-0 right-0 text-white font-bold text-xs text-center">
+                        {typeof value === 'number'
+                          ? value.toLocaleString()
+                          : value}
+                      </div>
+                    )}
+
+                    {/* Shine Effect */}
+                    <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white to-transparent opacity-20 rounded-t-lg"></div>
+                  </div>
+
+                  {/* Base */}
+                  <div className="w-full h-1 bg-gray-300 rounded-b-lg shadow-sm"></div>
+
+                  {/* Label - 조건부 표시 */}
+                  {(() => {
+                    const totalBars = values.length;
+                    let shouldShowLabel = false;
+
+                    if (totalBars <= 10) {
+                      // 10개 이하면 모든 라벨 표시
+                      shouldShowLabel = true;
+                    } else if (totalBars <= 20) {
+                      // 20개 이하면 2개마다 표시
+                      shouldShowLabel = index % 2 === 0;
+                    } else {
+                      // 20개 초과면 5개마다 표시
+                      shouldShowLabel =
+                        index % 5 === 0 || index === totalBars - 1;
+                    }
+
+                    if (shouldShowLabel) {
+                      return (
+                        <div className="mt-1 px-1 py-0.5 bg-white rounded text-xs font-medium text-gray-700 border border-gray-200 text-center">
+                          {labels[index]}
+                        </div>
+                      );
+                    }
+                    return null;
+                  })()}
+
+                  {/* Tooltip on hover for all bars */}
+                  <div className="absolute -top-12 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white text-xs px-2 py-1 rounded opacity-0 hover:opacity-100 transition-opacity pointer-events-none z-10">
+                    {labels[index]}:{' '}
+                    {typeof value === 'number' ? value.toLocaleString() : value}
+                  </div>
+                </div>
               );
-            });
-          })()}
-        </svg>
+            })}
+          </div>
+        </div>
+
+        {/* Background Grid */}
+        <div className="absolute inset-0 opacity-5 pointer-events-none">
+          <div
+            className="h-full w-full"
+            style={{
+              backgroundImage:
+                'linear-gradient(0deg, rgba(59,130,246,0.5) 1px, transparent 1px)',
+              backgroundSize: '100% 20px',
+            }}
+          ></div>
+        </div>
       </div>
     </div>
   );

--- a/src/features/admin/components/ChartSection.jsx
+++ b/src/features/admin/components/ChartSection.jsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import {
+  generateChartData,
+  generateChartPath,
+  getChartTitle,
+} from '../utils/statisticsUtils.js';
+
+/**
+ * 차트 섹션 컴포넌트
+ * @param {Object} props - 컴포넌트 props
+ * @param {string} props.activeTab - 활성 탭
+ * @param {Object} props.stats - 통계 데이터
+ * @param {boolean} props.loading - 로딩 상태
+ * @returns {JSX.Element} 차트 섹션 컴포넌트
+ */
+const ChartSection = ({ activeTab, stats, loading }) => {
+  const chartTitle = getChartTitle(activeTab);
+
+  // 전체 탭의 경우 차트 대신 메시지 표시
+  if (activeTab === '전체') {
+    return (
+      <div className="w-full bg-white rounded-lg border border-gray-200 p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-4">
+          <h3 className="text-lg font-semibold text-gray-900">{chartTitle}</h3>
+        </div>
+
+        <div className="w-full h-64 lg:h-80 bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg flex items-center justify-center relative">
+          <div className="text-center text-gray-500 py-12">
+            <svg
+              className="w-16 h-16 mx-auto mb-4 text-gray-300"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fillRule="evenodd"
+                d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+                clipRule="evenodd"
+              />
+            </svg>
+            <h3 className="text-lg font-medium mb-2">전체 통계 대시보드</h3>
+            <p className="text-sm">
+              상단 카드에서 모든 영역의 주요 지표를 확인하세요.
+            </p>
+            <p className="text-sm mt-1">
+              세부 차트는 개별 탭에서 확인할 수 있습니다.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 로딩 상태
+  if (loading) {
+    return (
+      <div className="w-full bg-white rounded-lg border border-gray-200 p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-4">
+          <h3 className="text-lg font-semibold text-gray-900">{chartTitle}</h3>
+        </div>
+
+        <div className="w-full h-64 lg:h-80 bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg flex items-center justify-center relative">
+          <div className="flex items-center space-x-2">
+            <div className="w-6 h-6 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
+            <span className="text-gray-600">차트 데이터 로딩 중...</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 통계 데이터가 없는 경우
+  if (!stats) {
+    return (
+      <div className="w-full bg-white rounded-lg border border-gray-200 p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-4">
+          <h3 className="text-lg font-semibold text-gray-900">{chartTitle}</h3>
+        </div>
+
+        <div className="w-full h-64 lg:h-80 bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg flex items-center justify-center relative">
+          <div className="text-gray-500 text-center">
+            <div className="text-lg font-medium mb-2">데이터 없음</div>
+            <div className="text-sm">통계 데이터를 불러올 수 없습니다.</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 차트 데이터 생성
+  const chartData = generateChartData(activeTab, stats);
+  const { values, max, labels } = chartData;
+  const chartPath = generateChartPath(values, max);
+  const fillPath = chartPath + ' L750,200 L50,200 Z';
+
+  return (
+    <div className="w-full bg-white rounded-lg border border-gray-200 p-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-4">
+        <h3 className="text-lg font-semibold text-gray-900">{chartTitle}</h3>
+      </div>
+
+      {/* Chart */}
+      <div className="w-full h-64 lg:h-80 bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg flex items-center justify-center relative">
+        <svg viewBox="0 0 800 200" className="w-full h-full max-w-full">
+          <defs>
+            <linearGradient
+              id="chartGradient"
+              x1="0%"
+              y1="0%"
+              x2="0%"
+              y2="100%"
+            >
+              <stop
+                offset="0%"
+                style={{
+                  stopColor: '#3B82F6',
+                  stopOpacity: 0.8,
+                }}
+              />
+              <stop
+                offset="100%"
+                style={{
+                  stopColor: '#3B82F6',
+                  stopOpacity: 0.1,
+                }}
+              />
+            </linearGradient>
+          </defs>
+          <path d={chartPath} fill="none" stroke="#3B82F6" strokeWidth="3" />
+          <path d={fillPath} fill="url(#chartGradient)" />
+          {values.map((value, index) => {
+            const x = 50 + index * (700 / (values.length - 1));
+            const y = 160 - (value / max) * 160 + 40;
+            return (
+              <circle
+                key={index}
+                cx={x}
+                cy={y}
+                r="4"
+                fill="#3B82F6"
+                stroke="white"
+                strokeWidth="2"
+              />
+            );
+          })}
+        </svg>
+        <div className="absolute bottom-4 left-6 flex justify-between w-full pr-12 text-sm text-gray-600">
+          {labels.slice(0, 5).map((label, index) => (
+            <span key={index}>{label}</span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChartSection;

--- a/src/features/admin/components/DateSelector.jsx
+++ b/src/features/admin/components/DateSelector.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { CONSTANTS } from '../utils/statisticsUtils.js';
+
+/**
+ * 날짜 선택기 컴포넌트
+ * @param {Object} props - 컴포넌트 props
+ * @param {number} props.selectedYear - 선택된 연도
+ * @param {number|null} props.selectedMonth - 선택된 월
+ * @param {number|null} props.selectedDay - 선택된 일
+ * @param {Function} props.onYearChange - 연도 변경 핸들러
+ * @param {Function} props.onMonthChange - 월 변경 핸들러
+ * @param {Function} props.onDayChange - 일 변경 핸들러
+ * @param {Function} props.onRefresh - 새로고침 핸들러
+ * @param {boolean} props.loading - 로딩 상태
+ * @returns {JSX.Element} 날짜 선택기 컴포넌트
+ */
+const DateSelector = ({
+  selectedYear,
+  selectedMonth,
+  selectedDay,
+  onYearChange,
+  onMonthChange,
+  onDayChange,
+  onRefresh,
+  loading,
+}) => {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-4">
+        {/* Year Selector */}
+        <div className="flex items-center space-x-2">
+          <label className="text-sm font-medium text-gray-700">연도:</label>
+          <select
+            value={selectedYear}
+            onChange={(e) => onYearChange(parseInt(e.target.value))}
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            disabled={loading}
+          >
+            {CONSTANTS.YEARS.map((year) => (
+              <option key={year} value={year}>
+                {year}년
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Month Selector */}
+        <div className="flex items-center space-x-2">
+          <label className="text-sm font-medium text-gray-700">월:</label>
+          <select
+            value={selectedMonth || ''}
+            onChange={(e) =>
+              onMonthChange(e.target.value ? parseInt(e.target.value) : null)
+            }
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            disabled={loading}
+          >
+            <option value="">전체</option>
+            {CONSTANTS.MONTHS.map((month) => (
+              <option key={month} value={month}>
+                {month}월
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Day Selector */}
+        <div className="flex items-center space-x-2">
+          <label className="text-sm font-medium text-gray-700">일:</label>
+          <select
+            value={selectedDay || ''}
+            onChange={(e) =>
+              onDayChange(e.target.value ? parseInt(e.target.value) : null)
+            }
+            className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            disabled={loading || !selectedMonth}
+          >
+            <option value="">전체</option>
+            {CONSTANTS.DAYS.map((day) => (
+              <option key={day} value={day}>
+                {day}일
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Refresh Button */}
+        <button
+          onClick={onRefresh}
+          disabled={loading}
+          className="px-4 py-2 text-sm text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 flex items-center space-x-2"
+        >
+          <svg
+            className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+          <span>{loading ? '로딩 중...' : '새로고침'}</span>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DateSelector;

--- a/src/features/admin/components/DistributionChart.jsx
+++ b/src/features/admin/components/DistributionChart.jsx
@@ -1,0 +1,437 @@
+import React from 'react';
+import { getDistributionTitle } from '../utils/statisticsUtils.js';
+import {
+  formatNumber,
+  formatPercent,
+  formatCurrency,
+} from '../utils/statisticsUtils.js';
+
+/**
+ * 분포 범례 컴포넌트
+ * @param {Object} props - 컴포넌트 props
+ * @param {string} props.activeTab - 활성 탭
+ * @param {Object} props.stats - 통계 데이터
+ * @returns {JSX.Element|null} 분포 범례 컴포넌트
+ */
+const DistributionLegend = ({ activeTab, stats }) => {
+  if (activeTab === '회원현황' && stats) {
+    return (
+      <div className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-4 text-sm">
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-blue-500 rounded-full mr-2"></div>
+          <span>활성 회원</span>
+          <span className="ml-2 font-semibold text-blue-600">
+            {formatNumber(stats.totalUsers - stats.withdrawCount)}명
+          </span>
+        </div>
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-red-500 rounded-full mr-2"></div>
+          <span>탈퇴 회원</span>
+          <span className="ml-2 font-semibold text-red-600">
+            {formatNumber(stats.withdrawCount)}명
+          </span>
+        </div>
+      </div>
+    );
+  } else if (activeTab === '정산' && stats) {
+    return (
+      <div className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-4 text-sm">
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-green-500 rounded-full mr-2"></div>
+          <span>완료</span>
+          <span className="ml-2 font-semibold text-green-600">
+            {formatNumber(stats.paidCount)}건
+          </span>
+        </div>
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-orange-500 rounded-full mr-2"></div>
+          <span>대기</span>
+          <span className="ml-2 font-semibold text-orange-600">
+            {formatNumber(stats.requestedCount - stats.paidCount)}건
+          </span>
+        </div>
+      </div>
+    );
+  } else if (activeTab === '결제' && stats) {
+    return (
+      <div className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-4 text-sm">
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-blue-500 rounded-full mr-2"></div>
+          <span>카드</span>
+          <span className="ml-2 font-semibold text-blue-600">
+            {formatCurrency(stats.card)}
+          </span>
+        </div>
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-green-500 rounded-full mr-2"></div>
+          <span>계좌이체</span>
+          <span className="ml-2 font-semibold text-green-600">
+            {formatCurrency(stats.transfer)}
+          </span>
+        </div>
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-orange-500 rounded-full mr-2"></div>
+          <span>현금</span>
+          <span className="ml-2 font-semibold text-orange-600">
+            {formatCurrency(stats.cash)}
+          </span>
+        </div>
+      </div>
+    );
+  } else if (activeTab === '예약관리' && stats) {
+    const completedCount = stats.reservationCount - stats.cancelledCount;
+    return (
+      <div className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-4 text-sm">
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-green-500 rounded-full mr-2"></div>
+          <span>완료</span>
+          <span className="ml-2 font-semibold text-green-600">
+            {formatNumber(completedCount)}건
+          </span>
+        </div>
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-red-500 rounded-full mr-2"></div>
+          <span>취소</span>
+          <span className="ml-2 font-semibold text-red-600">
+            {formatNumber(stats.cancelledCount)}건
+          </span>
+        </div>
+      </div>
+    );
+  } else if (activeTab === '매니저별점' && stats) {
+    return (
+      <div className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-4 text-sm">
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-yellow-500 rounded-full mr-2"></div>
+          <span>평균 평점</span>
+          <span className="ml-2 font-semibold text-yellow-600">
+            {stats.avgRating.toFixed(2)}점
+          </span>
+        </div>
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-blue-500 rounded-full mr-2"></div>
+          <span>리뷰 수</span>
+          <span className="ml-2 font-semibold text-blue-600">
+            {formatNumber(stats.reviewCount)}건
+          </span>
+        </div>
+      </div>
+    );
+  } else if (activeTab === '매칭' && stats) {
+    return (
+      <div className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-4 text-sm">
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-green-500 rounded-full mr-2"></div>
+          <span>성공</span>
+          <span className="ml-2 font-semibold text-green-600">
+            {formatNumber(stats.successCount)}건
+          </span>
+        </div>
+        <div className="flex items-center">
+          <div className="w-3 h-3 bg-red-500 rounded-full mr-2"></div>
+          <span>실패/취소</span>
+          <span className="ml-2 font-semibold text-red-600">
+            {formatNumber(stats.failCount)}건
+          </span>
+        </div>
+      </div>
+    );
+  }
+  return null;
+};
+
+/**
+ * 분포 바 차트 컴포넌트
+ * @param {Object} props - 컴포넌트 props
+ * @param {string} props.activeTab - 활성 탭
+ * @param {Object} props.stats - 통계 데이터
+ * @returns {JSX.Element|null} 분포 바 차트 컴포넌트
+ */
+const DistributionBars = ({ activeTab, stats }) => {
+  if (activeTab === '회원현황' && stats) {
+    return (
+      <>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">활성 회원</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-blue-500 h-4 rounded-full"
+              style={{
+                width: `${((stats.totalUsers - stats.withdrawCount) / stats.totalUsers) * 100}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent(
+              ((stats.totalUsers - stats.withdrawCount) / stats.totalUsers) *
+                100
+            )}
+          </div>
+        </div>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">탈퇴 회원</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-red-500 h-4 rounded-full"
+              style={{
+                width: `${(stats.withdrawCount / stats.totalUsers) * 100}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent((stats.withdrawCount / stats.totalUsers) * 100)}
+          </div>
+        </div>
+      </>
+    );
+  } else if (activeTab === '정산' && stats) {
+    return (
+      <>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">완료</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-green-500 h-4 rounded-full"
+              style={{
+                width: `${(stats.paidCount / stats.requestedCount) * 100}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent((stats.paidCount / stats.requestedCount) * 100)}
+          </div>
+        </div>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">대기</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-orange-500 h-4 rounded-full"
+              style={{
+                width: `${((stats.requestedCount - stats.paidCount) / stats.requestedCount) * 100}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent(
+              ((stats.requestedCount - stats.paidCount) /
+                stats.requestedCount) *
+                100
+            )}
+          </div>
+        </div>
+      </>
+    );
+  } else if (activeTab === '결제' && stats) {
+    const totalPayment = stats.card + stats.transfer + stats.cash;
+    return (
+      <>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">카드</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-blue-500 h-4 rounded-full"
+              style={{
+                width: `${(stats.card / totalPayment) * 100}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent((stats.card / totalPayment) * 100)}
+          </div>
+        </div>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">계좌이체</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-green-500 h-4 rounded-full"
+              style={{
+                width: `${(stats.transfer / totalPayment) * 100}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent((stats.transfer / totalPayment) * 100)}
+          </div>
+        </div>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">현금</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-orange-500 h-4 rounded-full"
+              style={{
+                width: `${(stats.cash / totalPayment) * 100}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent((stats.cash / totalPayment) * 100)}
+          </div>
+        </div>
+      </>
+    );
+  } else if (activeTab === '예약관리' && stats) {
+    const completedCount = stats.reservationCount - stats.cancelledCount;
+    return (
+      <>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">완료</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-green-500 h-4 rounded-full"
+              style={{
+                width: `${(completedCount / stats.reservationCount) * 100}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent((completedCount / stats.reservationCount) * 100)}
+          </div>
+        </div>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">취소</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-red-500 h-4 rounded-full"
+              style={{
+                width: `${(stats.cancelledCount / stats.reservationCount) * 100}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent(
+              (stats.cancelledCount / stats.reservationCount) * 100
+            )}
+          </div>
+        </div>
+      </>
+    );
+  } else if (activeTab === '매니저별점' && stats) {
+    // 5점 만점 기준 평점 분포 시각화
+    const ratingPercent = (stats.avgRating / 5) * 100;
+    const reviewCountLevel =
+      stats.reviewCount > 500 ? 100 : (stats.reviewCount / 500) * 100;
+
+    return (
+      <>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">평점</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-yellow-500 h-4 rounded-full"
+              style={{
+                width: `${ratingPercent}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent(ratingPercent)}
+          </div>
+        </div>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">참여도</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-blue-500 h-4 rounded-full"
+              style={{
+                width: `${reviewCountLevel}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent(reviewCountLevel)}
+          </div>
+        </div>
+      </>
+    );
+  } else if (activeTab === '매칭' && stats) {
+    return (
+      <>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">성공</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-green-500 h-4 rounded-full"
+              style={{
+                width: `${(stats.successCount / stats.totalCount) * 100}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent((stats.successCount / stats.totalCount) * 100)}
+          </div>
+        </div>
+        <div className="flex items-center">
+          <div className="w-16 sm:w-20 text-sm text-gray-600">실패/취소</div>
+          <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
+            <div
+              className="bg-red-500 h-4 rounded-full"
+              style={{
+                width: `${(stats.failCount / stats.totalCount) * 100}%`,
+              }}
+            ></div>
+          </div>
+          <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
+            {formatPercent((stats.failCount / stats.totalCount) * 100)}
+          </div>
+        </div>
+      </>
+    );
+  }
+  return null;
+};
+
+/**
+ * 분포 차트 컴포넌트
+ * @param {Object} props - 컴포넌트 props
+ * @param {string} props.activeTab - 활성 탭
+ * @param {Object} props.stats - 통계 데이터
+ * @param {boolean} props.loading - 로딩 상태
+ * @returns {JSX.Element|null} 분포 차트 컴포넌트
+ */
+const DistributionChart = ({ activeTab, stats, loading }) => {
+  // 전체 탭에서는 분포 차트를 표시하지 않음
+  if (activeTab === '전체') {
+    return null;
+  }
+
+  const distributionTitle = getDistributionTitle(activeTab);
+
+  return (
+    <div className="w-full mt-6 bg-white rounded-lg border border-gray-200 p-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-4">
+        <h3 className="text-lg font-semibold text-gray-900">
+          {distributionTitle}
+        </h3>
+        {!loading && <DistributionLegend activeTab={activeTab} stats={stats} />}
+      </div>
+
+      {/* Bar chart */}
+      <div className="space-y-4 w-full">
+        {loading ? (
+          <>
+            <div className="flex items-center">
+              <div className="w-16 h-4 bg-gray-200 rounded animate-pulse mr-4"></div>
+              <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4 animate-pulse"></div>
+              <div className="w-12 h-4 bg-gray-200 rounded animate-pulse"></div>
+            </div>
+            <div className="flex items-center">
+              <div className="w-16 h-4 bg-gray-200 rounded animate-pulse mr-4"></div>
+              <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4 animate-pulse"></div>
+              <div className="w-12 h-4 bg-gray-200 rounded animate-pulse"></div>
+            </div>
+          </>
+        ) : stats ? (
+          <DistributionBars activeTab={activeTab} stats={stats} />
+        ) : (
+          <div className="flex items-center justify-center py-8">
+            <div className="text-sm text-gray-500">
+              데이터를 불러올 수 없습니다.
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DistributionChart;

--- a/src/features/admin/components/SettlementDetailModal.jsx
+++ b/src/features/admin/components/SettlementDetailModal.jsx
@@ -266,41 +266,90 @@ const SettlementDetailModal = ({
                   <div className="w-2 h-6 bg-green-500 rounded-full mr-3"></div>
                   <h4 className="text-lg font-bold text-gray-900">금액 정보</h4>
                 </div>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                  <div className="text-center p-6 bg-gray-50 rounded-lg border border-gray-200">
-                    <div className="text-2xl font-bold text-gray-900 mb-2">
-                      {formatCurrency(
-                        settlementDetail.settlement?.totalAmount ||
-                          settlementDetail.totalAmount
+                {(() => {
+                  // 총 환불금액 계산 (참고용)
+                  const totalRefunded = settlementDetail.payments
+                    ? settlementDetail.payments.reduce(
+                        (sum, payment) => sum + (payment.refundedAmount || 0),
+                        0
+                      )
+                    : 0;
+
+                  // 실제 정산 금액 계산 (netAmount 사용)
+                  const actualTotalAmount = settlementDetail.payments
+                    ? settlementDetail.payments.reduce(
+                        (sum, payment) =>
+                          sum +
+                          (payment.netAmount ||
+                            payment.amount - (payment.refundedAmount || 0)),
+                        0
+                      )
+                    : settlementDetail.settlement?.totalAmount ||
+                      settlementDetail.totalAmount;
+
+                  return (
+                    <>
+                      <div className="mb-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                        <div className="text-sm text-blue-800 font-medium mb-2">
+                          💰 최종 정산 금액
+                        </div>
+                        <div className="text-xs text-blue-600 mb-3">
+                          ※ 아래 금액들은 환불을 제외한 실제 정산 금액입니다
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <div className="text-center p-6 bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg border border-blue-200">
+                          <div className="text-2xl font-bold text-blue-900 mb-2">
+                            {formatCurrency(actualTotalAmount)}
+                          </div>
+                          <div className="text-sm font-medium text-blue-700">
+                            실제 정산 금액
+                          </div>
+                        </div>
+                        <div className="text-center p-6 bg-gradient-to-br from-green-50 to-green-100 rounded-lg border border-green-200">
+                          <div className="text-2xl font-bold text-green-900 mb-2">
+                            {formatCurrency(
+                              settlementDetail.settlement?.managerAmount ||
+                                settlementDetail.managerAmount
+                            )}
+                          </div>
+                          <div className="text-sm font-medium text-green-700">
+                            매니저 정산액 (80%)
+                          </div>
+                          <div className="text-xs text-green-600 mt-1">
+                            실제 지급 금액
+                          </div>
+                        </div>
+                        <div className="text-center p-6 bg-gradient-to-br from-purple-50 to-purple-100 rounded-lg border border-purple-200">
+                          <div className="text-2xl font-bold text-purple-900 mb-2">
+                            {formatCurrency(
+                              settlementDetail.settlement?.adminAmount ||
+                                settlementDetail.adminAmount
+                            )}
+                          </div>
+                          <div className="text-sm font-medium text-purple-700">
+                            관리자 수수료 (20%)
+                          </div>
+                          <div className="text-xs text-purple-600 mt-1">
+                            실제 수익 금액
+                          </div>
+                        </div>
+                      </div>
+                      {totalRefunded > 0 && (
+                        <div className="mt-4 p-3 bg-gray-50 border border-gray-200 rounded-lg">
+                          <div className="text-xs text-gray-600 font-medium mb-1">
+                            📊 참고 정보
+                          </div>
+                          <div className="text-xs text-gray-500">
+                            이번 정산 기간에 총 {formatCurrency(totalRefunded)}
+                            의 환불이 발생했으며, 위 금액들은 환불을 제외한 최종
+                            정산 금액입니다.
+                          </div>
+                        </div>
                       )}
-                    </div>
-                    <div className="text-sm font-medium text-gray-600">
-                      총 수익
-                    </div>
-                  </div>
-                  <div className="text-center p-6 bg-gray-50 rounded-lg border border-gray-200">
-                    <div className="text-2xl font-bold text-gray-900 mb-2">
-                      {formatCurrency(
-                        settlementDetail.settlement?.managerAmount ||
-                          settlementDetail.managerAmount
-                      )}
-                    </div>
-                    <div className="text-sm font-medium text-gray-600">
-                      매니저 정산액 (80%)
-                    </div>
-                  </div>
-                  <div className="text-center p-6 bg-gray-50 rounded-lg border border-gray-200">
-                    <div className="text-2xl font-bold text-gray-900 mb-2">
-                      {formatCurrency(
-                        settlementDetail.settlement?.adminAmount ||
-                          settlementDetail.adminAmount
-                      )}
-                    </div>
-                    <div className="text-sm font-medium text-gray-600">
-                      관리자 수수료 (20%)
-                    </div>
-                  </div>
-                </div>
+                    </>
+                  );
+                })()}
               </div>
 
               {/* 결제 내역 */}
@@ -438,45 +487,79 @@ const SettlementDetailModal = ({
                               )}
                             </div>
                             <div className="text-right ml-6">
-                              <p className="text-xl font-bold text-gray-900 mb-2">
-                                {formatCurrency(payment.amount)}
-                              </p>
-                              <span
-                                className={`inline-flex px-3 py-1 text-sm font-semibold rounded-full ${
-                                  payment.status === 'PAID' ||
-                                  payment.status === 'COMPLETED'
-                                    ? 'bg-green-100 text-green-800'
-                                    : payment.status === 'PENDING' ||
-                                        payment.status === 'PROCESSING'
-                                      ? 'bg-yellow-100 text-yellow-800'
-                                      : payment.status === 'FAILED' ||
-                                          payment.status === 'CANCELLED'
-                                        ? 'bg-red-100 text-red-800'
-                                        : payment.status === 'PARTIAL_REFUNDED'
-                                          ? 'bg-orange-100 text-orange-800'
-                                          : payment.status === 'REFUNDED'
-                                            ? 'bg-purple-100 text-purple-800'
-                                            : 'bg-gray-100 text-gray-800'
-                                }`}
-                              >
-                                {payment.status === 'PAID' ||
-                                payment.status === 'COMPLETED'
-                                  ? '결제완료'
-                                  : payment.status === 'PENDING'
-                                    ? '결제대기'
-                                    : payment.status === 'PROCESSING'
-                                      ? '처리중'
-                                      : payment.status === 'FAILED'
-                                        ? '결제실패'
-                                        : payment.status === 'CANCELLED'
-                                          ? '결제취소'
+                              <div className="space-y-2">
+                                <div className="flex flex-col items-end">
+                                  {payment.refundedAmount &&
+                                  payment.refundedAmount > 0 ? (
+                                    <>
+                                      <div className="text-xs text-gray-500 mb-1">
+                                        원래 결제금액
+                                      </div>
+                                      <p className="text-lg text-gray-400 line-through">
+                                        {formatCurrency(payment.amount)}
+                                      </p>
+                                      <div className="text-xs text-orange-600 mt-1">
+                                        환불: -
+                                        {formatCurrency(payment.refundedAmount)}
+                                      </div>
+
+                                      <p className="text-xl font-bold text-blue-900">
+                                        {formatCurrency(
+                                          payment.netAmount ||
+                                            payment.amount -
+                                              payment.refundedAmount
+                                        )}
+                                      </p>
+                                    </>
+                                  ) : (
+                                    <>
+                                      <p className="text-xl font-bold text-blue-900">
+                                        {formatCurrency(
+                                          payment.netAmount || payment.amount
+                                        )}
+                                      </p>
+                                    </>
+                                  )}
+                                </div>
+                                <span
+                                  className={`inline-flex px-3 py-1 text-sm font-semibold rounded-full ${
+                                    payment.status === 'PAID' ||
+                                    payment.status === 'COMPLETED'
+                                      ? 'bg-green-100 text-green-800'
+                                      : payment.status === 'PENDING' ||
+                                          payment.status === 'PROCESSING'
+                                        ? 'bg-yellow-100 text-yellow-800'
+                                        : payment.status === 'FAILED' ||
+                                            payment.status === 'CANCELLED'
+                                          ? 'bg-red-100 text-red-800'
                                           : payment.status ===
                                               'PARTIAL_REFUNDED'
-                                            ? '부분환불'
+                                            ? 'bg-orange-100 text-orange-800'
                                             : payment.status === 'REFUNDED'
-                                              ? '전액환불'
-                                              : payment.status || '알 수 없음'}
-                              </span>
+                                              ? 'bg-purple-100 text-purple-800'
+                                              : 'bg-gray-100 text-gray-800'
+                                  }`}
+                                >
+                                  {payment.status === 'PAID' ||
+                                  payment.status === 'COMPLETED'
+                                    ? '결제완료'
+                                    : payment.status === 'PENDING'
+                                      ? '결제대기'
+                                      : payment.status === 'PROCESSING'
+                                        ? '처리중'
+                                        : payment.status === 'FAILED'
+                                          ? '결제실패'
+                                          : payment.status === 'CANCELLED'
+                                            ? '결제취소'
+                                            : payment.status ===
+                                                'PARTIAL_REFUNDED'
+                                              ? '부분환불'
+                                              : payment.status === 'REFUNDED'
+                                                ? '전액환불'
+                                                : payment.status ||
+                                                  '알 수 없음'}
+                                </span>
+                              </div>
                             </div>
                           </div>
                         </div>

--- a/src/features/admin/components/SettlementDetailModal.jsx
+++ b/src/features/admin/components/SettlementDetailModal.jsx
@@ -289,15 +289,7 @@ const SettlementDetailModal = ({
 
                   return (
                     <>
-                      <div className="mb-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-                        <div className="text-sm text-blue-800 font-medium mb-2">
-                          💰 최종 정산 금액
-                        </div>
-                        <div className="text-xs text-blue-600 mb-3">
-                          ※ 아래 금액들은 환불을 제외한 실제 정산 금액입니다
-                        </div>
-                      </div>
-                      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                         <div className="text-center p-6 bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg border border-blue-200">
                           <div className="text-2xl font-bold text-blue-900 mb-2">
                             {formatCurrency(actualTotalAmount)}
@@ -316,9 +308,6 @@ const SettlementDetailModal = ({
                           <div className="text-sm font-medium text-green-700">
                             매니저 정산액 (80%)
                           </div>
-                          <div className="text-xs text-green-600 mt-1">
-                            실제 지급 금액
-                          </div>
                         </div>
                         <div className="text-center p-6 bg-gradient-to-br from-purple-50 to-purple-100 rounded-lg border border-purple-200">
                           <div className="text-2xl font-bold text-purple-900 mb-2">
@@ -330,23 +319,16 @@ const SettlementDetailModal = ({
                           <div className="text-sm font-medium text-purple-700">
                             관리자 수수료 (20%)
                           </div>
-                          <div className="text-xs text-purple-600 mt-1">
-                            실제 수익 금액
+                        </div>
+                        <div className="text-center p-6 bg-gradient-to-br from-orange-50 to-orange-100 rounded-lg border border-orange-200">
+                          <div className="text-2xl font-bold text-orange-900 mb-2">
+                            {formatCurrency(totalRefunded)}
+                          </div>
+                          <div className="text-sm font-medium text-orange-700">
+                            총 환불 금액
                           </div>
                         </div>
                       </div>
-                      {totalRefunded > 0 && (
-                        <div className="mt-4 p-3 bg-gray-50 border border-gray-200 rounded-lg">
-                          <div className="text-xs text-gray-600 font-medium mb-1">
-                            📊 참고 정보
-                          </div>
-                          <div className="text-xs text-gray-500">
-                            이번 정산 기간에 총 {formatCurrency(totalRefunded)}
-                            의 환불이 발생했으며, 위 금액들은 환불을 제외한 최종
-                            정산 금액입니다.
-                          </div>
-                        </div>
-                      )}
                     </>
                   );
                 })()}
@@ -475,13 +457,15 @@ const SettlementDetailModal = ({
                                   </div>
                                 )}
                               </div>
-                              {payment.reservation?.customer && (
+                              {(payment.customerName ||
+                                payment.reservation?.customer?.name) && (
                                 <div className="flex items-center gap-2 mt-2">
                                   <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">
                                     고객
                                   </span>
                                   <span className="text-sm font-medium text-gray-900">
-                                    {payment.reservation.customer.name}
+                                    {payment.customerName ||
+                                      payment.reservation.customer.name}
                                   </span>
                                 </div>
                               )}

--- a/src/features/admin/components/TabNavigation.jsx
+++ b/src/features/admin/components/TabNavigation.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { CONSTANTS, isTabEnabled } from '../utils/statisticsUtils.js';
+
+/**
+ * 탭 네비게이션 컴포넌트
+ * @param {Object} props - 컴포넌트 props
+ * @param {string} props.activeTab - 활성 탭
+ * @param {Function} props.onTabChange - 탭 변경 핸들러
+ * @param {boolean} props.loading - 로딩 상태
+ * @returns {JSX.Element} 탭 네비게이션 컴포넌트
+ */
+const TabNavigation = ({ activeTab, onTabChange, loading }) => {
+  return (
+    <div className="w-full bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="flex overflow-x-auto bg-white">
+        {CONSTANTS.MAIN_TABS.map((tab) => {
+          const tabKey = tab.split(' ')[0];
+          const enabled = isTabEnabled(tabKey);
+
+          return (
+            <button
+              key={tab}
+              onClick={() => enabled && onTabChange(tabKey)}
+              className={`px-4 sm:px-6 py-4 text-sm font-medium transition-all duration-200 whitespace-nowrap ${
+                activeTab === tabKey
+                  ? 'text-blue-600 border-b-2 border-blue-500 bg-white'
+                  : enabled
+                    ? 'text-gray-500 hover:text-gray-700 hover:bg-gray-50 border-b-2 border-transparent bg-white'
+                    : 'text-gray-400 border-b-2 border-transparent bg-white cursor-not-allowed'
+              }`}
+              disabled={loading || !enabled}
+            >
+              {tab}
+              {!enabled && (
+                <span className="ml-2 text-xs text-gray-400">(준비중)</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="border-b border-gray-200 bg-white"></div>
+    </div>
+  );
+};
+
+export default TabNavigation;

--- a/src/features/admin/components/layout/Header.jsx
+++ b/src/features/admin/components/layout/Header.jsx
@@ -1,21 +1,21 @@
 import AlertCard from '@/features/alert/AlertCard';
 import { Bell } from 'lucide-react';
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 
 const Header = ({ isMobileMenuOpen, setIsMobileMenuOpen }) => {
   const location = useLocation();
-  const [lastUpdate, setLastUpdate] = useState(new Date());
+  //const [lastUpdate, setLastUpdate] = useState(new Date());
   const [open, setOpen] = useState(false);
 
   // 매 분마다 업데이트 시간 갱신
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setLastUpdate(new Date());
-    }, 60000); // 1분마다 업데이트
+  // useEffect(() => {
+  //   const interval = setInterval(() => {
+  //     setLastUpdate(new Date());
+  //   }, 60000); // 1분마다 업데이트
 
-    return () => clearInterval(interval);
-  }, []);
+  //   return () => clearInterval(interval);
+  // }, []);
 
   const getPageTitle = () => {
     const path = location.pathname;
@@ -104,14 +104,14 @@ const Header = ({ isMobileMenuOpen, setIsMobileMenuOpen }) => {
         <AlertCard onClose={closeAlert} isVisible={open}></AlertCard>
 
         {/* Right side - Real-time Update Indicator */}
-        <div className="flex items-center px-2 lg:px-3 xl:px-4">
+        {/* <div className="flex items-center px-2 lg:px-3 xl:px-4">
           <div className="text-sm text-gray-500">
             <span className="inline-flex items-center">
               <span className="w-2 h-2 rounded-full mr-2 bg-green-500"></span>
               실시간 업데이트: {lastUpdate.toLocaleString('ko-KR')}
             </span>
           </div>
-        </div>
+        </div> */}
       </div>
 
       {/* Mobile Menu Overlay */}

--- a/src/features/admin/data/statisticsData.jsx
+++ b/src/features/admin/data/statisticsData.jsx
@@ -1,0 +1,608 @@
+import {
+  formatNumber,
+  formatPercent,
+  formatCurrency,
+} from '../utils/statisticsUtils.js';
+
+/**
+ * 아이콘 컴포넌트들
+ */
+export const Icons = {
+  Users: () => (
+    <svg
+      className="w-5 h-5 text-blue-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z" />
+    </svg>
+  ),
+  Plus: () => (
+    <svg
+      className="w-5 h-5 text-green-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+  Minus: () => (
+    <svg
+      className="w-5 h-5 text-red-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+  Check: () => (
+    <svg
+      className="w-5 h-5 text-purple-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+  Money: () => (
+    <svg
+      className="w-5 h-5 text-blue-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path d="M8.433 7.418c.155-.103.346-.196.567-.267v1.698a2.305 2.305 0 01-.567-.267C8.07 8.34 8 8.114 8 8c0-.114.07-.34.433-.582zM11 12.849v-1.698c.22.071.412.164.567.267.364.243.433.468.433.582 0 .114-.07.34-.433.582a2.305 2.305 0 01-.567.267z" />
+      <path
+        fillRule="evenodd"
+        d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676.662C6.602 6.234 6 7.009 6 8c0 .99.602 1.765 1.324 2.246.48.32 1.054.545 1.676.662v1.941c-.391-.127-.68-.317-.843-.504a1 1 0 10-1.51 1.31c.562.649 1.413 1.076 2.353 1.253V15a1 1 0 102 0v-.092a4.535 4.535 0 001.676-.662C13.398 13.766 14 12.991 14 12c0-.99-.602-1.765-1.324-2.246A4.535 4.535 0 0011 9.092V7.151c.391.127.68.317.843.504a1 1 0 101.511-1.31c-.563-.649-1.413-1.076-2.354-1.253V5z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+  Calendar: () => (
+    <svg
+      className="w-5 h-5 text-blue-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+  Cancel: () => (
+    <svg
+      className="w-5 h-5 text-red-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+  Clock: () => (
+    <svg
+      className="w-5 h-5 text-purple-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+  List: () => (
+    <svg
+      className="w-5 h-5 text-blue-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+  Lightning: () => (
+    <svg
+      className="w-5 h-5 text-purple-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+  Star: () => (
+    <svg
+      className="w-5 h-5 text-yellow-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+    </svg>
+  ),
+  Chart: () => (
+    <svg
+      className="w-5 h-5 text-blue-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />
+    </svg>
+  ),
+  Wallet: () => (
+    <svg
+      className="w-5 h-5 text-teal-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+  ClipboardCheck: () => (
+    <svg
+      className="w-5 h-5 text-purple-600"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+};
+
+/**
+ * 날짜 포맷 생성 함수
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {string} 포맷된 날짜 문자열
+ */
+const formatDateRange = (year, month, day) => {
+  return `${year}년${month ? ` ${month}월` : ''}${day ? ` ${day}일` : ''}`;
+};
+
+/**
+ * 회원 통계 카드 데이터 생성
+ * @param {Object} userStats - 회원 통계 데이터
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Array} 카드 데이터 배열
+ */
+export const getUserStatsCards = (userStats, year, month, day) => {
+  if (!userStats) return [];
+
+  const withdrawRate =
+    userStats.totalUsers > 0
+      ? (userStats.withdrawCount / userStats.totalUsers) * 100
+      : 0;
+
+  return [
+    {
+      title: '누적 회원 수',
+      value: formatNumber(userStats.totalUsers),
+      subValue: formatDateRange(year, month, day),
+      icon: <Icons.Users />,
+      iconBg: 'bg-blue-100',
+    },
+    {
+      title: '신규 가입자',
+      value: formatNumber(userStats.signupCount),
+      subValue: formatDateRange(year, month, day),
+      icon: <Icons.Plus />,
+      iconBg: 'bg-green-100',
+    },
+    {
+      title: '탈퇴 회원',
+      value: formatNumber(userStats.withdrawCount),
+      subValue: `탈퇴율: ${formatPercent(withdrawRate)}`,
+      icon: <Icons.Minus />,
+      iconBg: 'bg-red-100',
+    },
+    {
+      title: '활성 회원',
+      value: formatNumber(userStats.totalUsers - userStats.withdrawCount),
+      subValue: '누적 - 탈퇴',
+      icon: <Icons.Check />,
+      iconBg: 'bg-purple-100',
+    },
+  ];
+};
+
+/**
+ * 정산 통계 카드 데이터 생성
+ * @param {Object} settlementStats - 정산 통계 데이터
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Array} 카드 데이터 배열
+ */
+export const getSettlementStatsCards = (settlementStats, year, month, day) => {
+  if (!settlementStats) return [];
+
+  const completionRate =
+    settlementStats.requestedCount > 0
+      ? (settlementStats.paidCount / settlementStats.requestedCount) * 100
+      : 0;
+
+  return [
+    {
+      title: '정산 신청 수',
+      value: formatNumber(settlementStats.requestedCount),
+      subValue: formatDateRange(year, month, day),
+      icon: <Icons.Money />,
+      iconBg: 'bg-blue-100',
+    },
+    {
+      title: '정산 완료 수',
+      value: formatNumber(settlementStats.paidCount),
+      subValue: formatDateRange(year, month, day),
+      icon: <Icons.Check />,
+      iconBg: 'bg-green-100',
+    },
+    {
+      title: '정산 완료율',
+      value: formatPercent(completionRate),
+      subValue: '신청 대비 완료',
+      icon: <Icons.ClipboardCheck />,
+      iconBg: 'bg-purple-100',
+    },
+    {
+      title: '정산 대기 수',
+      value: formatNumber(
+        settlementStats.requestedCount - settlementStats.paidCount
+      ),
+      subValue: '신청 - 완료',
+      icon: <Icons.Clock />,
+      iconBg: 'bg-orange-100',
+    },
+  ];
+};
+
+/**
+ * 결제 통계 카드 데이터 생성
+ * @param {Object} paymentStats - 결제 통계 데이터
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Array} 카드 데이터 배열
+ */
+export const getPaymentStatsCards = (paymentStats, year, month, day) => {
+  if (!paymentStats) return [];
+
+  const netAmount = paymentStats.totalAmount - paymentStats.cancelAmount;
+  const cancelRate =
+    paymentStats.paymentCount > 0
+      ? (paymentStats.cancelCount / paymentStats.paymentCount) * 100
+      : 0;
+
+  return [
+    {
+      title: '총 결제 금액',
+      value: formatCurrency(paymentStats.totalAmount),
+      subValue: formatDateRange(year, month, day),
+      icon: <Icons.Money />,
+      iconBg: 'bg-blue-100',
+    },
+    {
+      title: '취소 금액',
+      value: formatCurrency(paymentStats.cancelAmount),
+      subValue: `취소율: ${formatPercent(cancelRate)}`,
+      icon: <Icons.Minus />,
+      iconBg: 'bg-red-100',
+    },
+    {
+      title: '순 결제 금액',
+      value: formatCurrency(netAmount),
+      subValue: '총 결제 - 취소',
+      icon: <Icons.Check />,
+      iconBg: 'bg-green-100',
+    },
+    {
+      title: '결제 건수',
+      value: formatNumber(paymentStats.paymentCount),
+      subValue: `취소: ${formatNumber(paymentStats.cancelCount)}건`,
+      icon: <Icons.Calendar />,
+      iconBg: 'bg-purple-100',
+    },
+  ];
+};
+
+/**
+ * 예약 통계 카드 데이터 생성
+ * @param {Object} reservationStats - 예약 통계 데이터
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Array} 카드 데이터 배열
+ */
+export const getReservationStatsCards = (
+  reservationStats,
+  year,
+  month,
+  day
+) => {
+  if (!reservationStats) return [];
+
+  const completedCount =
+    reservationStats.reservationCount - reservationStats.cancelledCount;
+  const cancelRate =
+    reservationStats.reservationCount > 0
+      ? (reservationStats.cancelledCount / reservationStats.reservationCount) *
+        100
+      : 0;
+
+  return [
+    {
+      title: '총 예약 수',
+      value: formatNumber(reservationStats.reservationCount),
+      subValue: formatDateRange(year, month, day),
+      icon: <Icons.Calendar />,
+      iconBg: 'bg-blue-100',
+    },
+    {
+      title: '취소 예약',
+      value: formatNumber(reservationStats.cancelledCount),
+      subValue: `취소율: ${formatPercent(cancelRate)}`,
+      icon: <Icons.Cancel />,
+      iconBg: 'bg-red-100',
+    },
+    {
+      title: '완료 예약',
+      value: formatNumber(completedCount),
+      subValue: `성공률: ${formatPercent(reservationStats.reservationSuccessRate)}`,
+      icon: <Icons.Check />,
+      iconBg: 'bg-green-100',
+    },
+    {
+      title: '평균 처리 시간',
+      value: `${reservationStats.avgProcessingMinutes}분`,
+      subValue: '예약 처리 소요 시간',
+      icon: <Icons.Clock />,
+      iconBg: 'bg-purple-100',
+    },
+  ];
+};
+
+/**
+ * 매니저 평점 통계 카드 데이터 생성
+ * @param {Object} managerRatingStats - 매니저 평점 통계 데이터
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Array} 카드 데이터 배열
+ */
+export const getManagerRatingStatsCards = (
+  managerRatingStats,
+  year,
+  month,
+  day
+) => {
+  if (!managerRatingStats) return [];
+
+  return [
+    {
+      title: '평균 평점',
+      value: `${managerRatingStats.avgRating.toFixed(2)}점`,
+      subValue: formatDateRange(year, month, day),
+      icon: <Icons.Star />,
+      iconBg: 'bg-yellow-100',
+    },
+    {
+      title: '리뷰 수',
+      value: formatNumber(managerRatingStats.reviewCount),
+      subValue: '평점 참여 건수',
+      icon: <Icons.Chart />,
+      iconBg: 'bg-blue-100',
+    },
+    {
+      title: '평점 만족도',
+      value:
+        managerRatingStats.avgRating >= 4.5
+          ? '매우 높음'
+          : managerRatingStats.avgRating >= 4.0
+            ? '높음'
+            : managerRatingStats.avgRating >= 3.5
+              ? '보통'
+              : '낮음',
+      subValue: `5점 만점 기준`,
+      icon: <Icons.Check />,
+      iconBg:
+        managerRatingStats.avgRating >= 4.5
+          ? 'bg-green-100'
+          : managerRatingStats.avgRating >= 4.0
+            ? 'bg-blue-100'
+            : 'bg-orange-100',
+    },
+    {
+      title: '평점 참여율',
+      value:
+        managerRatingStats.reviewCount > 1000
+          ? '매우 높음'
+          : managerRatingStats.reviewCount > 500
+            ? '높음'
+            : managerRatingStats.reviewCount > 100
+              ? '보통'
+              : '낮음',
+      subValue: '고객 참여도',
+      icon: <Icons.Users />,
+      iconBg: 'bg-purple-100',
+    },
+  ];
+};
+
+/**
+ * 매칭 통계 카드 데이터 생성
+ * @param {Object} matchingStats - 매칭 통계 데이터
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Array} 카드 데이터 배열
+ */
+export const getMatchingStatsCards = (matchingStats, year, month, day) => {
+  if (!matchingStats) return [];
+
+  const successRate =
+    matchingStats.totalCount > 0
+      ? (matchingStats.successCount / matchingStats.totalCount) * 100
+      : 0;
+  const failRate =
+    matchingStats.totalCount > 0
+      ? (matchingStats.failCount / matchingStats.totalCount) * 100
+      : 0;
+
+  return [
+    {
+      title: '총 매칭 시도',
+      value: formatNumber(matchingStats.totalCount),
+      subValue: formatDateRange(year, month, day),
+      icon: <Icons.List />,
+      iconBg: 'bg-blue-100',
+    },
+    {
+      title: '성공 매칭',
+      value: formatNumber(matchingStats.successCount),
+      subValue: `성공률: ${formatPercent(successRate)}`,
+      icon: <Icons.Check />,
+      iconBg: 'bg-green-100',
+    },
+    {
+      title: '실패/취소 매칭',
+      value: formatNumber(matchingStats.failCount),
+      subValue: `실패율: ${formatPercent(failRate)}`,
+      icon: <Icons.Cancel />,
+      iconBg: 'bg-red-100',
+    },
+    {
+      title: '매칭 효율성',
+      value: formatPercent(successRate),
+      subValue: '전체 시도 대비 성공',
+      icon: <Icons.Lightning />,
+      iconBg: 'bg-purple-100',
+    },
+  ];
+};
+
+/**
+ * 전체 통계 요약 카드 데이터 생성
+ * @param {Object} allStats - 모든 통계 데이터
+ * @returns {Array} 카드 데이터 배열
+ */
+export const getAllStatsCards = (allStats) => {
+  const {
+    userStats,
+    paymentStats,
+    reservationStats,
+    matchingStats,
+    managerRatingStats,
+    settlementStats,
+  } = allStats;
+  const cards = [];
+
+  // 회원 현황 카드
+  if (userStats) {
+    cards.push({
+      title: '총 회원 수',
+      value: formatNumber(userStats.totalUsers),
+      subValue: `신규: ${formatNumber(userStats.signupCount)}명`,
+      icon: <Icons.Users />,
+      iconBg: 'bg-blue-100',
+    });
+  }
+
+  // 결제 현황 카드
+  if (paymentStats) {
+    cards.push({
+      title: '총 결제 금액',
+      value: formatCurrency(paymentStats.totalAmount),
+      subValue: `결제 건수: ${formatNumber(paymentStats.paymentCount)}건`,
+      icon: <Icons.Money />,
+      iconBg: 'bg-green-100',
+    });
+  }
+
+  // 예약 현황 카드
+  if (reservationStats) {
+    cards.push({
+      title: '총 예약 수',
+      value: formatNumber(reservationStats.reservationCount),
+      subValue: `성공률: ${formatPercent(reservationStats.reservationSuccessRate)}`,
+      icon: <Icons.Calendar />,
+      iconBg: 'bg-purple-100',
+    });
+  }
+
+  // 매니저 평점 현황 카드
+  if (managerRatingStats) {
+    cards.push({
+      title: '평균 평점',
+      value: `${managerRatingStats.avgRating.toFixed(2)}점`,
+      subValue: `리뷰 수: ${formatNumber(managerRatingStats.reviewCount)}건`,
+      icon: <Icons.Star />,
+      iconBg: 'bg-yellow-100',
+    });
+  }
+
+  // 매칭 현황 카드
+  if (matchingStats) {
+    const successRate =
+      matchingStats.totalCount > 0
+        ? (matchingStats.successCount / matchingStats.totalCount) * 100
+        : 0;
+    cards.push({
+      title: '매칭 성공률',
+      value: formatPercent(successRate),
+      subValue: `총 시도: ${formatNumber(matchingStats.totalCount)}건`,
+      icon: <Icons.Lightning />,
+      iconBg: 'bg-orange-100',
+    });
+  }
+
+  // 정산 현황 카드
+  if (settlementStats) {
+    const completionRate =
+      settlementStats.requestedCount > 0
+        ? (settlementStats.paidCount / settlementStats.requestedCount) * 100
+        : 0;
+    cards.push({
+      title: '정산 완료율',
+      value: formatPercent(completionRate),
+      subValue: `완료: ${formatNumber(settlementStats.paidCount)}건`,
+      icon: <Icons.Wallet />,
+      iconBg: 'bg-teal-100',
+    });
+  }
+
+  return cards;
+};

--- a/src/features/admin/pages/CustomerPayment.jsx
+++ b/src/features/admin/pages/CustomerPayment.jsx
@@ -421,7 +421,9 @@ const CustomerPayment = () => {
             customerName: payment.customerName || '알 수 없음',
             managerName: '매니저 정보 없음',
             serviceName: '홈케어 서비스',
-            amount: payment.amount || 0,
+            amount: payment.netAmount || payment.amount || 0,
+            originalAmount: payment.amount || 0,
+            refundedAmount: payment.refundedAmount || 0,
             method: payment.paymentMethod || 'CARD',
             status: payment.status || 'PENDING',
             createdAt: payment.paidAt
@@ -518,13 +520,16 @@ const CustomerPayment = () => {
 
   // 통계 데이터 가져오기 (백엔드에 통계 API가 없으므로 클라이언트에서 계산)
   const calculateStats = (paymentsData, refundsData = []) => {
+    // 실제 결제금액 (환불 제외)
     const totalPayment = paymentsData
       .filter((p) => p.status === 'PAID')
       .reduce((sum, p) => sum + p.amount, 0);
 
-    const refundAmount = paymentsData
-      .filter((p) => p.status === 'REFUNDED')
-      .reduce((sum, p) => sum + p.amount, 0);
+    // 환불된 총 금액 계산 (refundedAmount 기준)
+    const refundAmount = paymentsData.reduce(
+      (sum, p) => sum + (p.refundedAmount || 0),
+      0
+    );
 
     const totalCount = paymentsData.length;
     const completedCount = paymentsData.filter(

--- a/src/features/admin/pages/CustomerPayment.jsx
+++ b/src/features/admin/pages/CustomerPayment.jsx
@@ -572,14 +572,14 @@ const CustomerPayment = () => {
   }, [allPayments, allRefunds]);
 
   // 정기적 자동 새로고침 (30초마다) - 실시간 동기화
-  useEffect(() => {
-    const interval = setInterval(async () => {
-      console.log('🔄 자동 새로고침 실행 (30초 주기)');
-      await fetchPayments(); // fetchPayments 내에서 fetchRefunds도 함께 호출됨
-    }, 30000); // 30초마다
+  // useEffect(() => {
+  //   const interval = setInterval(async () => {
+  //     console.log('🔄 자동 새로고침 실행 (30초 주기)');
+  //     await fetchPayments(); // fetchPayments 내에서 fetchRefunds도 함께 호출됨
+  //   }, 30000); // 30초마다
 
-    return () => clearInterval(interval);
-  }, []);
+  //   return () => clearInterval(interval);
+  // }, []);
 
   // 검색 핸들러 - 리뷰 관리와 동일한 방식
   const handleSearch = () => {

--- a/src/features/admin/pages/Dashboard.jsx
+++ b/src/features/admin/pages/Dashboard.jsx
@@ -83,7 +83,6 @@ const Dashboard = () => {
   const [dashboardStats, setDashboardStats] = useState({
     totalUsers: 0,
     activeManagers: 0,
-    totalPayments: 0,
     todayReservations: 0,
     pendingApprovals: 0,
     managerStatusDetails: {
@@ -92,6 +91,22 @@ const Dashboard = () => {
       active: 0,
       rejected: 0,
     },
+    // 백엔드 DTO에 맞춘 필드명
+    todayRevenue: 0,
+    weeklyRevenue: 0,
+    monthlyRevenue: 0,
+    totalPayments: 0,
+    netRevenue: 0,
+    totalRefundAmount: 0,
+    refundRate: 0,
+    platformProfit: 0,
+    managerSettlementAmount: 0,
+    profitRate: 0,
+    // 차트 데이터
+    dailyStats: [],
+    // 기존 필드들 (호환성)
+    totalPaymentAmount: 0,
+    totalSettlementAmount: 0,
   });
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
@@ -184,104 +199,19 @@ const Dashboard = () => {
     //return () => clearInterval(interval);
   }, []);
 
-  // 관리자용 통계 카드 설정
-  const adminStats = [
+  // 매출 중심 통계 카드 설정
+  const revenueStats = [
+    // 실시간 매출 현황
     {
-      title: '전체 사용자',
-      value: loading ? '...' : `${dashboardStats.totalUsers.toLocaleString()}`,
-      subValue: '',
-      change: '+12.3% 이번 달',
-      icon: (
-        <svg
-          className="w-5 h-5 text-blue-600"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z" />
-        </svg>
-      ),
-    },
-    {
-      title: '활성 매니저',
+      title: '오늘 매출',
       value: loading
         ? '...'
-        : `${dashboardStats.activeManagers.toLocaleString()}`,
-      subValue: loading ? '로딩 중...' : `승인완료된 매니저`,
-      change: '+15.2% 지난달 대비',
-      icon: (
-        <svg
-          className="w-5 h-5 text-green-600"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-        </svg>
-      ),
-    },
-    {
-      title: '승인 대기 매니저',
-      value: loading ? '...' : `${dashboardStats.pendingApprovals}`,
-      subValue: loading ? '로딩 중...' : '대기 + 검토 중',
-      icon: (
-        <svg
-          className="w-5 h-5 text-yellow-600"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            fillRule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"
-            clipRule="evenodd"
-          />
-        </svg>
-      ),
-    },
-    {
-      title: '오늘 예약',
-      value: loading ? '...' : `${dashboardStats.todayReservations}`,
+        : `₩${dashboardStats.todayRevenue.toLocaleString()}`,
       subValue: loading ? '로딩 중...' : '실시간 업데이트',
       change: '+18.5% 어제 대비',
       icon: (
         <svg
           className="w-5 h-5 text-blue-600"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            fillRule="evenodd"
-            d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
-            clipRule="evenodd"
-          />
-        </svg>
-      ),
-    },
-    {
-      title: '전체 결제 건수',
-      value: loading
-        ? '...'
-        : `${dashboardStats.totalPayments.toLocaleString()}`,
-      subValue: loading ? '로딩 중...' : '누적 결제 건수',
-      change: '+25.7% 이번 달',
-      icon: (
-        <svg
-          className="w-5 h-5 text-purple-600"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z" />
-        </svg>
-      ),
-    },
-    {
-      title: '총 결제 금액',
-      value: loading
-        ? '...'
-        : `${(dashboardStats.totalPaymentAmount / 10000).toLocaleString()}만원`,
-      subValue: loading ? '로딩 중...' : '누적 결제 금액',
-      change: '+32.1% 이번 달',
-      icon: (
-        <svg
-          className="w-5 h-5 text-emerald-600"
           fill="currentColor"
           viewBox="0 0 20 20"
         >
@@ -295,12 +225,120 @@ const Dashboard = () => {
       ),
     },
     {
-      title: '총 정산 금액',
+      title: '이번 주 매출',
       value: loading
         ? '...'
-        : `${(dashboardStats.totalSettlementAmount / 10000).toLocaleString()}만원`,
-      subValue: loading ? '로딩 중...' : '매니저 정산 금액',
-      change: '+28.4% 이번 달',
+        : `₩${dashboardStats.weeklyRevenue.toLocaleString()}`,
+      subValue: loading ? '로딩 중...' : '월~일 기준',
+      change: '+25.3% 지난주 대비',
+      icon: (
+        <svg
+          className="w-5 h-5 text-emerald-600"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path
+            fillRule="evenodd"
+            d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ),
+    },
+    {
+      title: '이번 달 매출',
+      value: loading
+        ? '...'
+        : `₩${dashboardStats.monthlyRevenue.toLocaleString()}`,
+      subValue: loading ? '로딩 중...' : '월 누적',
+      change: '+32.1% 지난달 대비',
+      icon: (
+        <svg
+          className="w-5 h-5 text-purple-600"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z" />
+        </svg>
+      ),
+    },
+    {
+      title: '순 매출',
+      value: loading ? '...' : `₩${dashboardStats.netRevenue.toLocaleString()}`,
+      subValue: loading ? '로딩 중...' : '환불 제외',
+      change: '+15.8% 지난달 대비',
+      icon: (
+        <svg
+          className="w-5 h-5 text-green-600"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path
+            fillRule="evenodd"
+            d="M12 7a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0V8.414l-4.293 4.293a1 1 0 01-1.414 0L8 10.414l-4.293 4.293a1 1 0 01-1.414-1.414l5-5a1 1 0 011.414 0L11 10.586 14.586 7H12z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ),
+    },
+    {
+      title: '전체 결제 금액',
+      value: loading
+        ? '...'
+        : `₩${dashboardStats.totalPayments.toLocaleString()}`,
+      subValue: loading ? '로딩 중...' : '누적 총액',
+      change: '+22.7% 지난달 대비',
+      icon: (
+        <svg
+          className="w-5 h-5 text-slate-600"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path d="M4 4a2 2 0 00-2 2v1h16V6a2 2 0 00-2-2H4z" />
+          <path
+            fillRule="evenodd"
+            d="M18 9H2v5a2 2 0 002 2h12a2 2 0 002-2V9zM4 13a1 1 0 011-1h1a1 1 0 110 2H5a1 1 0 01-1-1zm5-1a1 1 0 100 2h1a1 1 0 100-2H9z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ),
+    },
+    // 환불 관련 정보
+    {
+      title: '총 환불 금액',
+      value: loading
+        ? '...'
+        : `₩${dashboardStats.totalRefundAmount.toLocaleString()}`,
+      subValue: loading
+        ? '로딩 중...'
+        : `환불률 ${dashboardStats.refundRate.toFixed(2)}%`,
+      change: '-5.2% 지난달 대비',
+      changeType: 'decrease',
+      icon: (
+        <svg
+          className="w-5 h-5 text-red-600"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path
+            fillRule="evenodd"
+            d="M8 7a1 1 0 012 0v2h2a1 1 0 110 2h-2v2a1 1 0 11-2 0v-2H6a1 1 0 110-2h2V7z"
+            clipRule="evenodd"
+          />
+          <path
+            fillRule="evenodd"
+            d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489a.5.5 0 01-.493.611H6.99a.5.5 0 01-.493-.611L6.62 15H5a2 2 0 01-2-2V5z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ),
+    },
+    {
+      title: '환불률',
+      value: loading ? '...' : `${dashboardStats.refundRate.toFixed(2)}%`,
+      subValue: loading ? '로딩 중...' : '전체 결제 대비',
+      change: '-2.1% 지난달 대비',
+      changeType: 'decrease',
       icon: (
         <svg
           className="w-5 h-5 text-orange-600"
@@ -309,9 +347,44 @@ const Dashboard = () => {
         >
           <path
             fillRule="evenodd"
-            d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"
             clipRule="evenodd"
           />
+        </svg>
+      ),
+    },
+    // 수익 분석
+    {
+      title: '관리자 수익 (20%)',
+      value: loading
+        ? '...'
+        : `₩${dashboardStats.platformProfit.toLocaleString()}`,
+      subValue: loading ? '로딩 중...' : '플랫폼 수수료',
+      change: '+28.4% 지난달 대비',
+      icon: (
+        <svg
+          className="w-5 h-5 text-indigo-600"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3z" />
+        </svg>
+      ),
+    },
+    {
+      title: '매니저 정산 (80%)',
+      value: loading
+        ? '...'
+        : `₩${dashboardStats.managerSettlementAmount.toLocaleString()}`,
+      subValue: loading ? '로딩 중...' : '매니저 수익',
+      change: '+30.2% 지난달 대비',
+      icon: (
+        <svg
+          className="w-5 h-5 text-teal-600"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z" />
         </svg>
       ),
     },
@@ -321,9 +394,9 @@ const Dashboard = () => {
     <div className="min-h-screen bg-gray-50 overflow-x-hidden">
       <div className="px-4 sm:px-6 lg:px-8 py-6">
         <div className="max-w-none space-y-6">
-          {/* Stats Grid */}
+          {/* Revenue Stats Grid */}
           <div className="w-full grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-            {adminStats.map((stat, index) => (
+            {revenueStats.map((stat, index) => (
               <StatCard
                 key={index}
                 title={stat.title}
@@ -331,74 +404,495 @@ const Dashboard = () => {
                 subValue={stat.subValue}
                 icon={stat.icon}
                 change={stat.change}
+                changeType={stat.changeType}
                 loading={loading}
               />
             ))}
           </div>
 
-          {/* Chart Section */}
-          <div className="w-full bg-white rounded-2xl p-6 shadow-sm border border-gray-100">
-            <div className="mb-6">
-              <h2 className="text-lg font-semibold text-gray-900">
-                매출 추이 (최근 7일)
-              </h2>
+          {/* Charts Section */}
+          <div className="w-full grid grid-cols-1 xl:grid-cols-2 gap-6">
+            {/* 매출 추이 차트 */}
+            <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100">
+              <div className="mb-6 flex items-center justify-between">
+                <h2 className="text-xl font-semibold text-gray-900">
+                  매출 추이 (최근 7일)
+                </h2>
+                <div className="flex items-center space-x-4 text-base">
+                  <div className="flex items-center">
+                    <div className="w-4 h-4 bg-blue-800 rounded-full mr-2"></div>
+                    <span className="text-gray-600">총 매출</span>
+                  </div>
+                  <div className="flex items-center">
+                    <div className="w-4 h-4 bg-orange-600 rounded-full mr-2"></div>
+                    <span className="text-gray-600">순 매출</span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="w-full h-80 bg-gradient-to-r from-gray-50 to-gray-100 rounded-lg flex items-center justify-center relative">
+                {dashboardStats.dailyStats &&
+                dashboardStats.dailyStats.length > 0 ? (
+                  <svg
+                    viewBox="0 0 800 320"
+                    className="w-full h-full max-w-full"
+                  >
+                    <defs>
+                      <linearGradient
+                        id="revenueGradient"
+                        x1="0%"
+                        y1="0%"
+                        x2="0%"
+                        y2="100%"
+                      >
+                        <stop
+                          offset="0%"
+                          style={{ stopColor: '#1E40AF', stopOpacity: 0.6 }}
+                        />
+                        <stop
+                          offset="100%"
+                          style={{ stopColor: '#1E40AF', stopOpacity: 0.1 }}
+                        />
+                      </linearGradient>
+                      <linearGradient
+                        id="netRevenueGradient"
+                        x1="0%"
+                        y1="0%"
+                        x2="0%"
+                        y2="100%"
+                      >
+                        <stop
+                          offset="0%"
+                          style={{ stopColor: '#EA580C', stopOpacity: 0.6 }}
+                        />
+                        <stop
+                          offset="100%"
+                          style={{ stopColor: '#EA580C', stopOpacity: 0.1 }}
+                        />
+                      </linearGradient>
+                    </defs>
+
+                    {(() => {
+                      const maxPayment = Math.max(
+                        ...dashboardStats.dailyStats.map((d) => d.paymentAmount)
+                      );
+                      const chartHeight = 240;
+                      const chartTop = 30;
+
+                      if (maxPayment === 0) {
+                        return (
+                          <text
+                            x="400"
+                            y="100"
+                            textAnchor="middle"
+                            className="text-sm fill-gray-500"
+                          >
+                            데이터가 없습니다
+                          </text>
+                        );
+                      }
+
+                      // 7개 데이터 포인트를 균등하게 배치
+                      const chartWidth = 600; // 차트 영역 너비
+                      const chartStartX = 100; // 시작 X 좌표
+                      const dataCount = dashboardStats.dailyStats.length;
+                      const spacing =
+                        dataCount > 1 ? chartWidth / (dataCount - 1) : 0;
+
+                      // 총 매출과 순 매출 경로 생성
+                      const totalPath = dashboardStats.dailyStats
+                        .map((data, i) => {
+                          const x = chartStartX + i * spacing;
+                          const y =
+                            chartTop +
+                            (chartHeight -
+                              (data.paymentAmount / maxPayment) * chartHeight);
+                          return `${i === 0 ? 'M' : 'L'}${x},${y}`;
+                        })
+                        .join(' ');
+
+                      const netPath = dashboardStats.dailyStats
+                        .map((data, i) => {
+                          const netAmount =
+                            data.paymentAmount - data.refundAmount;
+                          const x = chartStartX + i * spacing;
+                          const y =
+                            chartTop +
+                            (chartHeight -
+                              (netAmount / maxPayment) * chartHeight);
+                          return `${i === 0 ? 'M' : 'L'}${x},${y}`;
+                        })
+                        .join(' ');
+
+                      // 영역 채우기용 경로
+                      const lastX = chartStartX + (dataCount - 1) * spacing;
+                      const areaBottom = chartTop + chartHeight;
+                      const totalAreaPath =
+                        totalPath +
+                        ` L${lastX},${areaBottom} L${chartStartX},${areaBottom} Z`;
+                      const netAreaPath =
+                        netPath +
+                        ` L${lastX},${areaBottom} L${chartStartX},${areaBottom} Z`;
+
+                      return (
+                        <>
+                          {/* 총 매출 영역 */}
+                          <path
+                            d={totalAreaPath}
+                            fill="url(#revenueGradient)"
+                          />
+                          {/* 순 매출 영역 */}
+                          <path
+                            d={netAreaPath}
+                            fill="url(#netRevenueGradient)"
+                          />
+
+                          {/* 총 매출 라인 */}
+                          <path
+                            d={totalPath}
+                            fill="none"
+                            stroke="#1E40AF"
+                            strokeWidth="3"
+                          />
+                          {/* 순 매출 라인 */}
+                          <path
+                            d={netPath}
+                            fill="none"
+                            stroke="#EA580C"
+                            strokeWidth="3"
+                          />
+
+                          {/* 데이터 포인트 */}
+                          {dashboardStats.dailyStats.map((data, i) => {
+                            const x = chartStartX + i * spacing;
+                            const totalY =
+                              chartTop +
+                              (chartHeight -
+                                (data.paymentAmount / maxPayment) *
+                                  chartHeight);
+                            const netAmount =
+                              data.paymentAmount - data.refundAmount;
+                            const netY =
+                              chartTop +
+                              (chartHeight -
+                                (netAmount / maxPayment) * chartHeight);
+
+                            return (
+                              <g key={i}>
+                                <circle
+                                  cx={x}
+                                  cy={totalY}
+                                  r="6"
+                                  fill="#1E40AF"
+                                  stroke="white"
+                                  strokeWidth="3"
+                                />
+                                <circle
+                                  cx={x}
+                                  cy={netY}
+                                  r="6"
+                                  fill="#EA580C"
+                                  stroke="white"
+                                  strokeWidth="3"
+                                />
+                              </g>
+                            );
+                          })}
+
+                          {/* 날짜 라벨 */}
+                          {dashboardStats.dailyStats.map((data, i) => {
+                            const x = chartStartX + i * spacing;
+                            const date = new Date(data.date);
+                            const dateLabel = `${date.getMonth() + 1}/${date.getDate()}`;
+
+                            return (
+                              <text
+                                key={i}
+                                x={x}
+                                y="305"
+                                textAnchor="middle"
+                                className="text-sm fill-gray-600"
+                                fontSize="16"
+                              >
+                                {dateLabel}
+                              </text>
+                            );
+                          })}
+                        </>
+                      );
+                    })()}
+                  </svg>
+                ) : (
+                  <div className="text-gray-500">데이터가 없습니다</div>
+                )}
+              </div>
             </div>
 
-            {/* Placeholder for chart */}
-            <div className="w-full h-64 lg:h-80 bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg flex items-center justify-center relative chart-container">
-              <svg viewBox="0 0 800 200" className="w-full h-full max-w-full">
-                <defs>
-                  <linearGradient
-                    id="gradient"
-                    x1="0%"
-                    y1="0%"
-                    x2="0%"
-                    y2="100%"
+            {/* 환불 추이 차트 */}
+            <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100">
+              <div className="mb-6 flex items-center justify-between">
+                <h2 className="text-xl font-semibold text-gray-900">
+                  환불 현황 (최근 7일)
+                </h2>
+                <div className="flex items-center space-x-4 text-base">
+                  <div className="flex items-center">
+                    <div className="w-4 h-4 bg-red-500 rounded-full mr-2"></div>
+                    <span className="text-gray-600">환불 금액</span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="w-full h-80 bg-gradient-to-r from-red-50 to-orange-50 rounded-lg flex items-center justify-center relative">
+                {dashboardStats.dailyStats &&
+                dashboardStats.dailyStats.length > 0 ? (
+                  <svg
+                    viewBox="0 0 800 320"
+                    className="w-full h-full max-w-full"
                   >
-                    <stop
-                      offset="0%"
-                      style={{ stopColor: '#3B82F6', stopOpacity: 0.8 }}
-                    />
-                    <stop
-                      offset="100%"
-                      style={{ stopColor: '#3B82F6', stopOpacity: 0.1 }}
-                    />
-                  </linearGradient>
-                </defs>
-                <path
-                  d="M50,150 L150,120 L250,100 L350,80 L450,70 L550,60 L650,50 L750,40"
-                  fill="none"
-                  stroke="#3B82F6"
-                  strokeWidth="3"
-                />
-                <path
-                  d="M50,150 L150,120 L250,100 L350,80 L450,70 L550,60 L650,50 L750,40 L750,200 L50,200 Z"
-                  fill="url(#gradient)"
-                />
-                {/* Data points */}
-                {[50, 150, 250, 350, 450, 550, 650, 750].map((x, i) => {
-                  const y = 150 - i * 15;
-                  return (
-                    <circle
-                      key={i}
-                      cx={x}
-                      cy={y}
-                      r="4"
-                      fill="#3B82F6"
-                      stroke="white"
-                      strokeWidth="2"
-                    />
-                  );
-                })}
-              </svg>
-              <div className="absolute bottom-4 left-6 flex space-x-6 text-sm text-gray-600">
-                <span>1/9</span>
-                <span>1/10</span>
-                <span>1/11</span>
-                <span>1/12</span>
-                <span>1/13</span>
-                <span>1/14</span>
-                <span>1/15</span>
+                    <defs>
+                      <linearGradient
+                        id="refundGradient"
+                        x1="0%"
+                        y1="0%"
+                        x2="0%"
+                        y2="100%"
+                      >
+                        <stop
+                          offset="0%"
+                          style={{ stopColor: '#EF4444', stopOpacity: 0.6 }}
+                        />
+                        <stop
+                          offset="100%"
+                          style={{ stopColor: '#EF4444', stopOpacity: 0.1 }}
+                        />
+                      </linearGradient>
+                    </defs>
+
+                    {(() => {
+                      const maxRefund = Math.max(
+                        ...dashboardStats.dailyStats.map((d) => d.refundAmount)
+                      );
+                      const chartHeight = 240;
+                      const chartTop = 30;
+
+                      // 7개 데이터 포인트를 균등하게 배치
+                      const chartWidth = 600; // 차트 영역 너비
+                      const chartStartX = 100; // 시작 X 좌표
+                      const dataCount = dashboardStats.dailyStats.length;
+                      const spacing =
+                        dataCount > 1 ? chartWidth / (dataCount - 1) : 0;
+
+                      if (maxRefund === 0) {
+                        return (
+                          <text
+                            x="400"
+                            y="100"
+                            textAnchor="middle"
+                            className="text-sm fill-gray-500"
+                          >
+                            환불 데이터가 없습니다
+                          </text>
+                        );
+                      }
+
+                      return (
+                        <>
+                          {/* 환불 금액 바 차트 */}
+                          {dashboardStats.dailyStats.map((data, i) => {
+                            const x = chartStartX + i * spacing;
+                            const height =
+                              maxRefund > 0
+                                ? (data.refundAmount / maxRefund) * chartHeight
+                                : 0;
+                            const y = chartTop + chartHeight - height;
+
+                            return (
+                              <rect
+                                key={i}
+                                x={x - 25}
+                                y={y}
+                                width="50"
+                                height={height}
+                                fill="url(#refundGradient)"
+                                rx="6"
+                              />
+                            );
+                          })}
+
+                          {/* 날짜 라벨 */}
+                          {dashboardStats.dailyStats.map((data, i) => {
+                            const x = chartStartX + i * spacing;
+                            const date = new Date(data.date);
+                            const dateLabel = `${date.getMonth() + 1}/${date.getDate()}`;
+
+                            return (
+                              <text
+                                key={i}
+                                x={x}
+                                y="305"
+                                textAnchor="middle"
+                                className="text-sm fill-gray-600"
+                                fontSize="16"
+                              >
+                                {dateLabel}
+                              </text>
+                            );
+                          })}
+                        </>
+                      );
+                    })()}
+                  </svg>
+                ) : (
+                  <div className="text-gray-500">데이터가 없습니다</div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 수익률 분석 섹션 */}
+          <div className="w-full bg-white rounded-2xl p-6 shadow-sm border border-gray-100">
+            <div className="mb-6">
+              <h2 className="text-xl font-semibold text-gray-900">
+                수익률 분석
+              </h2>
+              <p className="text-base text-gray-600 mt-1">
+                플랫폼 수수료와 매니저 정산 비율 현황
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+              {/* 수익 분배 도넛 차트 */}
+              <div className="flex flex-col items-center">
+                <div className="relative w-48 h-48">
+                  <svg
+                    viewBox="0 0 200 200"
+                    className="w-full h-full transform -rotate-90"
+                  >
+                    {(() => {
+                      const circumference = 2 * Math.PI * 80; // 503
+                      const platformRate = loading
+                        ? 20
+                        : dashboardStats.profitRate;
+                      const managerRate = 100 - platformRate;
+
+                      const platformArc = (platformRate / 100) * circumference;
+                      const managerArc = (managerRate / 100) * circumference;
+
+                      return (
+                        <>
+                          {/* 매니저 정산 */}
+                          <circle
+                            cx="100"
+                            cy="100"
+                            r="80"
+                            fill="none"
+                            stroke="#10B981"
+                            strokeWidth="20"
+                            strokeDasharray={`${managerArc} ${circumference}`}
+                            strokeDashoffset="0"
+                          />
+                          {/* 플랫폼 수익 */}
+                          <circle
+                            cx="100"
+                            cy="100"
+                            r="80"
+                            fill="none"
+                            stroke="#6366F1"
+                            strokeWidth="20"
+                            strokeDasharray={`${platformArc} ${circumference}`}
+                            strokeDashoffset={`-${managerArc}`}
+                          />
+                        </>
+                      );
+                    })()}
+                  </svg>
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-gray-900">
+                        {loading
+                          ? '...'
+                          : `${dashboardStats.profitRate.toFixed(1)}%`}
+                      </div>
+                      <div className="text-base text-gray-600">수익률</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-4 space-y-2">
+                  <div className="flex items-center">
+                    <div className="w-5 h-5 bg-emerald-500 rounded mr-3"></div>
+                    <span className="text-base text-gray-700">
+                      매니저 정산 (
+                      {loading
+                        ? '80'
+                        : (100 - dashboardStats.profitRate).toFixed(1)}
+                      %)
+                    </span>
+                  </div>
+                  <div className="flex items-center">
+                    <div className="w-5 h-5 bg-indigo-500 rounded mr-3"></div>
+                    <span className="text-base text-gray-700">
+                      관리자 수익 (
+                      {loading ? '20' : dashboardStats.profitRate.toFixed(1)}%)
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* 수익률 상세 정보 */}
+              <div className="space-y-6">
+                <div className="bg-gradient-to-r from-green-50 to-emerald-50 p-4 rounded-lg border border-green-200">
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="text-base font-medium text-green-700">
+                      매니저 총 정산액
+                    </span>
+                    <span className="text-xl font-bold text-green-900">
+                      ₩
+                      {loading
+                        ? '...'
+                        : dashboardStats.managerSettlementAmount.toLocaleString()}
+                    </span>
+                  </div>
+                  <div className="text-sm text-green-600">
+                    전체 매출의{' '}
+                    {loading
+                      ? '80'
+                      : (100 - dashboardStats.profitRate).toFixed(1)}
+                    %
+                  </div>
+                </div>
+
+                <div className="bg-gradient-to-r from-indigo-50 to-purple-50 p-4 rounded-lg border border-indigo-200">
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="text-base font-medium text-indigo-700">
+                      플랫폼 수익
+                    </span>
+                    <span className="text-xl font-bold text-indigo-900">
+                      ₩
+                      {loading
+                        ? '...'
+                        : dashboardStats.platformProfit.toLocaleString()}
+                    </span>
+                  </div>
+                  <div className="text-sm text-indigo-600">
+                    전체 매출의{' '}
+                    {loading ? '20' : dashboardStats.profitRate.toFixed(1)}%
+                  </div>
+                </div>
+
+                <div className="bg-gradient-to-r from-gray-50 to-slate-50 p-4 rounded-lg border border-gray-200">
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="text-base font-medium text-gray-700">
+                      순수익률
+                    </span>
+                    <span className="text-xl font-bold text-gray-900">
+                      {loading
+                        ? '...'
+                        : `${dashboardStats.profitRate.toFixed(1)}%`}
+                    </span>
+                  </div>
+                  <div className="text-sm text-gray-600">환불 제외 기준</div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/features/admin/pages/Dashboard.jsx
+++ b/src/features/admin/pages/Dashboard.jsx
@@ -179,9 +179,9 @@ const Dashboard = () => {
     fetchDashboardStats();
 
     // 30초마다 데이터 새로고침 (실시간 업데이트)
-    const interval = setInterval(fetchDashboardStats, 30000);
+    //const interval = setInterval(fetchDashboardStats, 30000);
 
-    return () => clearInterval(interval);
+    //return () => clearInterval(interval);
   }, []);
 
   // 관리자용 통계 카드 설정

--- a/src/features/admin/pages/Inquiries.jsx
+++ b/src/features/admin/pages/Inquiries.jsx
@@ -382,7 +382,11 @@ const Inquiries = () => {
             Boolean(inquiry.replyContent);
 
           // userRole 필드 처리 - 다양한 가능성 고려
-          let userRole = inquiry.userRole || inquiry.role;
+          let userRole =
+            inquiry.userRole ||
+            inquiry.role ||
+            inquiry.writerRole ||
+            inquiry.authorRole;
 
           // 백엔드에서 문자열로 올 수도 있고 enum으로 올 수도 있음
           if (typeof userRole === 'string') {
@@ -392,6 +396,18 @@ const Inquiries = () => {
           // user 객체 안에 role이 있을 수도 있음
           if (!userRole && inquiry.user && inquiry.user.role) {
             userRole = inquiry.user.role.toUpperCase();
+          }
+
+          // 여전히 userRole이 없으면 현재 탭 기반으로 추측
+          if (!userRole) {
+            if (activeTab === '수요자문의') {
+              userRole = 'CUSTOMER';
+            } else if (activeTab === '매니저문의') {
+              userRole = 'MANAGER';
+            } else {
+              // 전체 탭인 경우 기본값으로 CUSTOMER 설정 (더 안전한 선택)
+              userRole = 'CUSTOMER';
+            }
           }
 
           // 개발 환경에서 각 문의글의 답변 상태 로깅

--- a/src/features/admin/pages/ManagerSettlement.jsx
+++ b/src/features/admin/pages/ManagerSettlement.jsx
@@ -677,12 +677,12 @@ const ManagerSettlement = () => {
                 </h3>
                 <div className="flex items-center space-x-3">
                   {/* 주간 정산 생성 버튼 */}
-                  {/* TODO: 주간 정산 생성 기능 구현 필요 */}
                   <button
                     onClick={() => {
                       alert('주간 정산 생성 기능은 준비 중입니다.');
                     }}
-                    className="px-4 py-2 text-black bg-green-600 rounded-lg hover:bg-green-700 transition-colors flex items-center space-x-2"
+                    disabled
+                    className="px-4 py-2 text-gray-500 bg-gray-200 rounded-lg cursor-not-allowed opacity-75 flex items-center space-x-2"
                   >
                     <svg
                       className="w-4 h-4"
@@ -697,7 +697,7 @@ const ManagerSettlement = () => {
                         d="M12 4v16m8-8H4"
                       />
                     </svg>
-                    <span>주간 정산 생성</span>
+                    <span>주간 정산 생성 (준비중)</span>
                   </button>
 
                   {/* 검색 범위 선택 */}

--- a/src/features/admin/pages/Statistics.jsx
+++ b/src/features/admin/pages/Statistics.jsx
@@ -446,6 +446,8 @@ const Statistics = () => {
               activeTab={activeMainTab}
               stats={getCurrentStats()}
               loading={loading}
+              selectedYear={selectedYear}
+              selectedMonth={selectedMonth}
             />
 
             {/* Distribution Chart */}

--- a/src/features/admin/pages/Statistics.jsx
+++ b/src/features/admin/pages/Statistics.jsx
@@ -98,12 +98,14 @@ const Statistics = () => {
   const [matchingStats, setMatchingStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [noData, setNoData] = useState(false); // 데이터 없음 상태
 
   // 통계 데이터 로드
   const loadStats = async () => {
     try {
       setLoading(true);
       setError(null);
+      setNoData(false); // 데이터 없음 상태 초기화
       console.log('📊 통계 로딩 시작:', {
         selectedYear,
         selectedMonth,
@@ -185,40 +187,17 @@ const Statistics = () => {
 
       // 404 오류인 경우 (데이터가 없는 경우)
       if (err.message && err.message.includes('404')) {
-        console.log('📅 404 오류 발생, 어제 날짜로 리셋 중...');
-
-        // 어제 날짜로 자동 리셋
-        const yesterday = new Date();
-        yesterday.setDate(yesterday.getDate() - 1);
-        const yesterdayYear = yesterday.getFullYear();
-        const yesterdayMonth = yesterday.getMonth() + 1;
-
-        // 선택된 날짜가 어제 날짜와 다른 경우에만 리셋
-        if (
-          selectedYear !== yesterdayYear ||
-          selectedMonth !== yesterdayMonth
-        ) {
-          setSelectedYear(yesterdayYear);
-          setSelectedMonth(yesterdayMonth);
-          setSelectedDay(null);
-
-          setError(
-            `${selectedYear}년 ${selectedMonth}월 데이터가 없습니다. 어제 날짜(${yesterdayYear}년 ${yesterdayMonth}월)로 자동 조회합니다.`
-          );
-
-          // 3초 후 오류 메시지 자동 제거
-          setTimeout(() => {
-            setError(null);
-          }, 3000);
-
-          return; // 리셋 후 다시 로드되므로 여기서 종료
-        }
-
-        setError(
-          `선택한 날짜의 통계 데이터가 존재하지 않습니다. 다른 날짜를 선택해주세요.`
+        console.log(
+          '📅 데이터 없음: 선택한 날짜에 통계 데이터가 존재하지 않습니다.'
         );
+
+        // 오류가 아닌 데이터 없음 상태로 처리
+        setNoData(true);
+        setError(null);
       } else {
+        // 실제 API 오류인 경우만 error 상태로 처리
         setError('통계 데이터를 불러오는 중 오류가 발생했습니다.');
+        setNoData(false);
       }
     } finally {
       setLoading(false);
@@ -403,6 +382,37 @@ const Statistics = () => {
                   >
                     다시 시도
                   </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* No Data Message */}
+          {noData && !error && (
+            <div className="w-full bg-blue-50 border border-blue-200 rounded-lg p-4 mb-4">
+              <div className="flex">
+                <div className="flex-shrink-0">
+                  <svg
+                    className="h-5 w-5 text-blue-400"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div className="ml-3">
+                  <p className="text-sm text-blue-700 mt-1">
+                    {selectedYear}년{selectedMonth ? ` ${selectedMonth}월` : ''}
+                    {selectedDay ? ` ${selectedDay}일` : ''}에 해당하는 통계
+                    데이터가 없습니다.
+                    <br />
+                    다른 날짜를 선택하시거나 데이터가 생성될 때까지 기다려
+                    주세요.
+                  </p>
                 </div>
               </div>
             </div>

--- a/src/features/admin/pages/Statistics.jsx
+++ b/src/features/admin/pages/Statistics.jsx
@@ -61,10 +61,33 @@ const StatCard = ({ title, value, subValue, icon, iconBg, loading }) => (
 );
 
 const Statistics = () => {
+  // 어제 날짜 정보 설정 (00시 기준으로 어제 데이터 표시)
+  const getYesterdayDate = () => {
+    const now = new Date();
+    const yesterday = new Date(now);
+    yesterday.setDate(yesterday.getDate() - 1); // 어제 날짜로 설정
+
+    console.log('📅 어제 날짜 설정:', {
+      현재: now.toISOString(),
+      어제: yesterday.toISOString(),
+      년도: yesterday.getFullYear(),
+      월: yesterday.getMonth() + 1,
+    });
+
+    return {
+      year: yesterday.getFullYear(),
+      month: yesterday.getMonth() + 1, // 0-based index이므로 +1
+      day: null, // 기본적으로 일별 조회는 하지 않음 (월별 조회)
+    };
+  };
+
+  const currentDate = getYesterdayDate();
+  console.log('🚀 Statistics 컴포넌트 초기화:', currentDate);
+
   const [activeMainTab, setActiveMainTab] = useState('전체');
-  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
-  const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth() + 1);
-  const [selectedDay, setSelectedDay] = useState(null);
+  const [selectedYear, setSelectedYear] = useState(currentDate.year);
+  const [selectedMonth, setSelectedMonth] = useState(currentDate.month);
+  const [selectedDay, setSelectedDay] = useState(currentDate.day);
 
   // 통계 데이터 상태
   const [userStats, setUserStats] = useState(null);
@@ -85,6 +108,9 @@ const Statistics = () => {
         selectedYear,
         selectedMonth,
         selectedDay,
+        현재날짜: new Date().toISOString(),
+        현재년도: new Date().getFullYear(),
+        현재월: new Date().getMonth() + 1,
       });
 
       if (activeMainTab === '전체') {
@@ -156,14 +182,99 @@ const Statistics = () => {
       }
     } catch (err) {
       console.error('💥 통계 로딩 실패:', err);
-      setError('통계 데이터를 불러오는 중 오류가 발생했습니다.');
+
+      // 404 오류인 경우 (데이터가 없는 경우)
+      if (err.message && err.message.includes('404')) {
+        console.log('📅 404 오류 발생, 어제 날짜로 리셋 중...');
+
+        // 어제 날짜로 자동 리셋
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1);
+        const yesterdayYear = yesterday.getFullYear();
+        const yesterdayMonth = yesterday.getMonth() + 1;
+
+        // 선택된 날짜가 어제 날짜와 다른 경우에만 리셋
+        if (
+          selectedYear !== yesterdayYear ||
+          selectedMonth !== yesterdayMonth
+        ) {
+          setSelectedYear(yesterdayYear);
+          setSelectedMonth(yesterdayMonth);
+          setSelectedDay(null);
+
+          setError(
+            `${selectedYear}년 ${selectedMonth}월 데이터가 없습니다. 어제 날짜(${yesterdayYear}년 ${yesterdayMonth}월)로 자동 조회합니다.`
+          );
+
+          // 3초 후 오류 메시지 자동 제거
+          setTimeout(() => {
+            setError(null);
+          }, 3000);
+
+          return; // 리셋 후 다시 로드되므로 여기서 종료
+        }
+
+        setError(
+          `선택한 날짜의 통계 데이터가 존재하지 않습니다. 다른 날짜를 선택해주세요.`
+        );
+      } else {
+        setError('통계 데이터를 불러오는 중 오류가 발생했습니다.');
+      }
     } finally {
       setLoading(false);
     }
   };
 
+  // 날짜 유효성 검사 (어제 기준)
+  const validateDate = (year, month, day) => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const yesterdayYear = yesterday.getFullYear();
+    const yesterdayMonth = yesterday.getMonth() + 1;
+    const yesterdayDay = yesterday.getDate();
+
+    console.log('📅 날짜 유효성 검사:', {
+      입력값: { year, month, day },
+      어제기준: {
+        year: yesterdayYear,
+        month: yesterdayMonth,
+        day: yesterdayDay,
+      },
+    });
+
+    // 어제보다 미래 날짜 체크
+    if (year > yesterdayYear) return false;
+    if (year === yesterdayYear && month > yesterdayMonth) return false;
+    if (
+      year === yesterdayYear &&
+      month === yesterdayMonth &&
+      day &&
+      day > yesterdayDay
+    )
+      return false;
+
+    return true;
+  };
+
   // 컴포넌트 마운트 시 및 연도/월/일 변경 시 데이터 로드
   useEffect(() => {
+    // 날짜 유효성 검사
+    if (!validateDate(selectedYear, selectedMonth, selectedDay)) {
+      console.warn(
+        '⚠️ 어제보다 미래 날짜가 선택되었습니다. 어제 날짜로 리셋합니다.'
+      );
+      const current = getYesterdayDate();
+      setSelectedYear(current.year);
+      setSelectedMonth(current.month);
+      setSelectedDay(current.day);
+      setError(
+        '어제보다 미래 날짜는 선택할 수 없습니다. 어제 날짜로 설정되었습니다.'
+      );
+      setTimeout(() => setError(null), 3000);
+      return;
+    }
+
     loadStats();
   }, [selectedYear, selectedMonth, selectedDay, activeMainTab]);
 

--- a/src/features/admin/pages/Statistics.jsx
+++ b/src/features/admin/pages/Statistics.jsx
@@ -1,4 +1,26 @@
 import React, { useState, useEffect } from 'react';
+import DateSelector from '../components/DateSelector.jsx';
+import TabNavigation from '../components/TabNavigation.jsx';
+import ChartSection from '../components/ChartSection.jsx';
+import DistributionChart from '../components/DistributionChart.jsx';
+import {
+  fetchAllStats,
+  fetchUserStats,
+  fetchSettlementStats,
+  fetchPaymentStats,
+  fetchReservationStats,
+  fetchManagerRatingStats,
+  fetchMatchingStats,
+} from '../services/statisticsAPI.js';
+import {
+  getUserStatsCards,
+  getSettlementStatsCards,
+  getPaymentStatsCards,
+  getReservationStatsCards,
+  getManagerRatingStatsCards,
+  getMatchingStatsCards,
+  getAllStatsCards,
+} from '../data/statisticsData.jsx';
 
 const StatCard = ({ title, value, subValue, icon, iconBg, loading }) => (
   <div className="bg-white rounded-2xl p-4 shadow-sm border border-gray-100 hover:shadow-md transition-shadow min-h-[140px] flex flex-col">
@@ -39,921 +61,190 @@ const StatCard = ({ title, value, subValue, icon, iconBg, loading }) => (
 );
 
 const Statistics = () => {
-  const [activeMainTab, setActiveMainTab] = useState('회원현황');
-  const [activeTimeTab, setActiveTimeTab] = useState('30일');
+  const [activeMainTab, setActiveMainTab] = useState('전체');
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
   const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth() + 1);
+  const [selectedDay, setSelectedDay] = useState(null);
 
   // 통계 데이터 상태
-  const [stats, setStats] = useState({
-    users: null,
-    settlements: null,
-    payments: null,
-    paymentMethods: null,
-    reservations: null,
-    matching: null,
-    managerRatings: null,
-  });
-
+  const [userStats, setUserStats] = useState(null);
+  const [settlementStats, setSettlementStats] = useState(null);
+  const [paymentStats, setPaymentStats] = useState(null);
+  const [reservationStats, setReservationStats] = useState(null);
+  const [managerRatingStats, setManagerRatingStats] = useState(null);
+  const [matchingStats, setMatchingStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const mainTabs = [
-    '회원현황 통계',
-    '정산 통계',
-    '결제 통계',
-    '매칭 통계',
-    '예약 통계',
-  ];
-  const timeTabs = ['7일', '30일', '90일'];
-  const years = [2023, 2024, 2025];
-  const months = Array.from({ length: 12 }, (_, i) => i + 1);
-
-  // API 호출 함수들
-  const fetchUserStats = async (year, month) => {
-    try {
-      const token = localStorage.getItem('accessToken');
-      const url = `/api/v1/admin/statistics/users?year=${year}&month=${month}`;
-
-      const response = await fetch(url, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        // CommonApiResponse 구조 처리
-        if (data && data.data) {
-          return data.data;
-        } else {
-          return data;
-        }
-      } else {
-        const errorText = await response.text();
-        console.error('❌ User stats error:', {
-          status: response.status,
-          error: errorText,
-        });
-      }
-      return null;
-    } catch (err) {
-      console.error('💥 Failed to fetch user stats:', err);
-      return null;
-    }
-  };
-
-  const fetchSettlementStats = async (year, month) => {
-    try {
-      const token = localStorage.getItem('accessToken');
-      const url = `/api/v1/admin/statistics/settlements?year=${year}&month=${month}`;
-
-      const response = await fetch(url, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        return data && data.data ? data.data : data;
-      } else {
-        const errorText = await response.text();
-        console.error('❌ Settlement stats error:', {
-          status: response.status,
-          error: errorText,
-        });
-      }
-      return null;
-    } catch (err) {
-      console.error('💥 Failed to fetch settlement stats:', err);
-      return null;
-    }
-  };
-
-  const fetchPaymentStats = async (year, month) => {
-    try {
-      const token = localStorage.getItem('accessToken');
-      const url = `/api/v1/admin/statistics/payments?year=${year}&month=${month}`;
-
-      const response = await fetch(url, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        return data && data.data ? data.data : data;
-      } else {
-        const errorText = await response.text();
-        console.error('❌ Payment stats error:', {
-          status: response.status,
-          error: errorText,
-        });
-      }
-      return null;
-    } catch (err) {
-      console.error('💥 Failed to fetch payment stats:', err);
-      return null;
-    }
-  };
-
-  const fetchReservationStats = async (year, month) => {
-    try {
-      const token = localStorage.getItem('accessToken');
-      const url = `/api/v1/admin/statistics/reservations?year=${year}&month=${month}`;
-
-      const response = await fetch(url, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        return data && data.data ? data.data : data;
-      } else {
-        const errorText = await response.text();
-        console.error('❌ Reservation stats error:', {
-          status: response.status,
-          error: errorText,
-        });
-      }
-      return null;
-    } catch (err) {
-      console.error('💥 Failed to fetch reservation stats:', err);
-      return null;
-    }
-  };
-
-  const fetchMatchingStats = async (year, month) => {
-    try {
-      const token = localStorage.getItem('accessToken');
-
-      const [successResponse, failResponse] = await Promise.all([
-        fetch(
-          `/api/v1/admin/statistics/matching/success?year=${year}&month=${month}`,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              'Content-Type': 'application/json',
-            },
-          }
-        ),
-        fetch(
-          `/api/v1/admin/statistics/matching/fail?year=${year}&month=${month}`,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              'Content-Type': 'application/json',
-            },
-          }
-        ),
-      ]);
-
-      const successData = successResponse.ok
-        ? await successResponse.json()
-        : null;
-      const failData = failResponse.ok ? await failResponse.json() : null;
-
-      return {
-        success:
-          successData && successData.data ? successData.data : successData,
-        fail: failData && failData.data ? failData.data : failData,
-      };
-    } catch (err) {
-      console.error('💥 Failed to fetch matching stats:', err);
-      return null;
-    }
-  };
-
-  // 모든 통계 데이터 로드
-  const loadAllStats = async () => {
+  // 통계 데이터 로드
+  const loadStats = async () => {
     try {
       setLoading(true);
       setError(null);
+      console.log('📊 통계 로딩 시작:', {
+        selectedYear,
+        selectedMonth,
+        selectedDay,
+      });
 
-      const [users, settlements, payments, reservations, matching] =
-        await Promise.all([
-          fetchUserStats(selectedYear, selectedMonth),
-          fetchSettlementStats(selectedYear, selectedMonth),
-          fetchPaymentStats(selectedYear, selectedMonth),
-          fetchReservationStats(selectedYear, selectedMonth),
-          fetchMatchingStats(selectedYear, selectedMonth),
-        ]);
+      if (activeMainTab === '전체') {
+        const allStats = await fetchAllStats(
+          selectedYear,
+          selectedMonth,
+          selectedDay
+        );
+        console.log('📈 받은 전체 통계 데이터:', allStats);
 
-      // 결제 수단 데이터는 월별 조회일 때만 payments 응답에 포함됨
-      const paymentMethods =
-        payments &&
-        (payments.card !== undefined ||
-          payments.transfer !== undefined ||
-          payments.cash !== undefined)
-          ? payments
-          : null;
-
-      const newStats = {
-        users,
-        settlements,
-        payments,
-        paymentMethods, // 월별일 때만 결제 수단 데이터 있음
-        reservations,
-        matching,
-      };
-
-      setStats(newStats);
+        // 모든 통계 데이터를 각각의 상태에 설정
+        if (allStats.userStats) setUserStats(allStats.userStats);
+        if (allStats.settlementStats)
+          setSettlementStats(allStats.settlementStats);
+        if (allStats.paymentStats) setPaymentStats(allStats.paymentStats);
+        if (allStats.reservationStats)
+          setReservationStats(allStats.reservationStats);
+        if (allStats.managerRatingStats)
+          setManagerRatingStats(allStats.managerRatingStats);
+        if (allStats.matchingStats) setMatchingStats(allStats.matchingStats);
+      } else if (activeMainTab === '회원현황') {
+        const stats = await fetchUserStats(
+          selectedYear,
+          selectedMonth,
+          selectedDay
+        );
+        console.log('📈 받은 회원 통계 데이터:', stats);
+        setUserStats(stats);
+      } else if (activeMainTab === '정산') {
+        const stats = await fetchSettlementStats(
+          selectedYear,
+          selectedMonth,
+          selectedDay
+        );
+        console.log('📈 받은 정산 통계 데이터:', stats);
+        setSettlementStats(stats);
+      } else if (activeMainTab === '결제') {
+        const stats = await fetchPaymentStats(
+          selectedYear,
+          selectedMonth,
+          selectedDay
+        );
+        console.log('📈 받은 결제 통계 데이터:', stats);
+        setPaymentStats(stats);
+      } else if (activeMainTab === '예약관리') {
+        const stats = await fetchReservationStats(
+          selectedYear,
+          selectedMonth,
+          selectedDay
+        );
+        console.log('📈 받은 예약 통계 데이터:', stats);
+        setReservationStats(stats);
+      } else if (activeMainTab === '매니저별점') {
+        const stats = await fetchManagerRatingStats(
+          selectedYear,
+          selectedMonth,
+          selectedDay
+        );
+        console.log('📈 받은 매니저별점 통계 데이터:', stats);
+        setManagerRatingStats(stats);
+      } else if (activeMainTab === '매칭') {
+        const stats = await fetchMatchingStats(
+          selectedYear,
+          selectedMonth,
+          selectedDay
+        );
+        console.log('📈 받은 매칭 통계 데이터:', stats);
+        setMatchingStats(stats);
+      }
     } catch (err) {
-      console.error('💥 Failed to load statistics:', err);
+      console.error('💥 통계 로딩 실패:', err);
       setError('통계 데이터를 불러오는 중 오류가 발생했습니다.');
     } finally {
       setLoading(false);
     }
   };
 
-  // 컴포넌트 마운트 시 및 연도/월 변경 시 데이터 로드
+  // 컴포넌트 마운트 시 및 연도/월/일 변경 시 데이터 로드
   useEffect(() => {
-    loadAllStats();
-  }, [selectedYear, selectedMonth]);
+    loadStats();
+  }, [selectedYear, selectedMonth, selectedDay, activeMainTab]);
 
-  // 금액 포맷팅
-  const formatCurrency = (amount) => {
-    if (!amount) return '₩0';
-    return `₩${amount.toLocaleString()}`;
-  };
-
-  // 숫자 포맷팅
-  const formatNumber = (number) => {
-    if (!number || isNaN(number) || !isFinite(number)) return '0';
-    return Number(number).toLocaleString();
-  };
-
-  // 퍼센트 포맷팅
-  const formatPercent = (percent) => {
-    if (!percent || isNaN(percent) || !isFinite(percent)) return '0%';
-    return `${Number(percent).toFixed(1)}%`;
-  };
-
-  // 차트 데이터 생성 함수
-  const getChartData = () => {
-    if (!stats) return { values: [], max: 100, labels: [] };
-
-    // 안전한 숫자 변환 함수
-    const safeNumber = (value, defaultValue = 0) => {
-      const num = Number(value);
-      return isNaN(num) || !isFinite(num) ? defaultValue : num;
+  // 현재 탭에 따른 통계 카드 반환
+  const getCurrentStatsCards = () => {
+    const allStatsData = {
+      userStats,
+      settlementStats,
+      paymentStats,
+      reservationStats,
+      managerRatingStats,
+      matchingStats,
     };
 
     switch (activeMainTab) {
-      case '회원현황': {
-        if (!stats.users) return { values: [], max: 100, labels: [] };
-        const totalUsers = safeNumber(stats.users.totalUsers, 100);
-        const signupCount = safeNumber(stats.users.signupCount, 0);
-        const withdrawCount = safeNumber(stats.users.withdrawCount, 0);
-        const inactiveUserCount = safeNumber(stats.users.inactiveUserCount, 0);
-
-        const maxValue = Math.max(totalUsers, 100);
-
-        return {
-          values: [
-            totalUsers * 0.7,
-            totalUsers * 0.75,
-            totalUsers * 0.8,
-            totalUsers * 0.85,
-            totalUsers * 0.9,
-            totalUsers * 0.95,
-            totalUsers,
-            totalUsers,
-          ],
-          max: maxValue * 1.2,
-          labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
-          mainValue: totalUsers,
-          subValues: [signupCount, withdrawCount, inactiveUserCount],
-        };
-      }
-
-      case '정산': {
-        if (!stats.settlements) return { values: [], max: 100, labels: [] };
-        const requestedCount = safeNumber(stats.settlements.requestedCount, 0);
-        const paidCount = safeNumber(stats.settlements.paidCount, 0);
-
-        const maxValue = Math.max(requestedCount, 10);
-
-        return {
-          values: [
-            paidCount * 0.3,
-            paidCount * 0.5,
-            paidCount * 0.65,
-            paidCount * 0.75,
-            paidCount * 0.85,
-            paidCount * 0.9,
-            paidCount * 0.95,
-            paidCount,
-          ],
-          max: maxValue * 1.2,
-          labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
-          mainValue: requestedCount,
-          subValues: [paidCount, requestedCount - paidCount],
-        };
-      }
-
-      case '결제': {
-        if (!stats.payments) return { values: [], max: 100, labels: [] };
-        const totalAmount = safeNumber(stats.payments.totalAmount, 0);
-        const cancelAmount = safeNumber(stats.payments.cancelAmount, 0);
-
-        const maxValue = Math.max(totalAmount, 1000);
-
-        return {
-          values: [
-            totalAmount * 0.4,
-            totalAmount * 0.55,
-            totalAmount * 0.7,
-            totalAmount * 0.8,
-            totalAmount * 0.85,
-            totalAmount * 0.9,
-            totalAmount * 0.95,
-            totalAmount,
-          ],
-          max: maxValue * 1.2,
-          labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
-          mainValue: totalAmount,
-          subValues: [totalAmount - cancelAmount, cancelAmount],
-        };
-      }
-
-      case '매칭': {
-        if (!stats.matching?.success || !stats.matching?.fail)
-          return { values: [], max: 100, labels: [] };
-        const successCount = safeNumber(stats.matching.success.successCount, 0);
-        const failCount = safeNumber(stats.matching.fail.failCount, 0);
-        const totalMatching = successCount + failCount;
-
-        const maxValue = Math.max(totalMatching, 10);
-
-        return {
-          values: [
-            totalMatching * 0.3,
-            totalMatching * 0.45,
-            totalMatching * 0.6,
-            totalMatching * 0.7,
-            totalMatching * 0.8,
-            totalMatching * 0.9,
-            totalMatching * 0.95,
-            totalMatching,
-          ],
-          max: maxValue * 1.2,
-          labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
-          mainValue: totalMatching,
-          subValues: [successCount, failCount],
-        };
-      }
-
-      case '예약': {
-        if (!stats.reservations) return { values: [], max: 100, labels: [] };
-        const reservationCount = safeNumber(
-          stats.reservations.reservationCount,
-          0
+      case '전체':
+        return getAllStatsCards(allStatsData);
+      case '회원현황':
+        return getUserStatsCards(
+          userStats,
+          selectedYear,
+          selectedMonth,
+          selectedDay
         );
-        const avgProcessingMinutes = safeNumber(
-          stats.reservations.avgProcessingMinutes,
-          0
+      case '정산':
+        return getSettlementStatsCards(
+          settlementStats,
+          selectedYear,
+          selectedMonth,
+          selectedDay
         );
-
-        const maxValue = Math.max(reservationCount, 10);
-
-        return {
-          values: [
-            reservationCount * 0.5,
-            reservationCount * 0.6,
-            reservationCount * 0.7,
-            reservationCount * 0.8,
-            reservationCount * 0.85,
-            reservationCount * 0.9,
-            reservationCount * 0.95,
-            reservationCount,
-          ],
-          max: maxValue * 1.2,
-          labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
-          mainValue: reservationCount,
-          subValues: [avgProcessingMinutes, Math.round(reservationCount / 365)],
-        };
-      }
-
+      case '결제':
+        return getPaymentStatsCards(
+          paymentStats,
+          selectedYear,
+          selectedMonth,
+          selectedDay
+        );
+      case '예약관리':
+        return getReservationStatsCards(
+          reservationStats,
+          selectedYear,
+          selectedMonth,
+          selectedDay
+        );
+      case '매니저별점':
+        return getManagerRatingStatsCards(
+          managerRatingStats,
+          selectedYear,
+          selectedMonth,
+          selectedDay
+        );
+      case '매칭':
+        return getMatchingStatsCards(
+          matchingStats,
+          selectedYear,
+          selectedMonth,
+          selectedDay
+        );
       default:
-        return { values: [], max: 100, labels: [] };
+        return [];
     }
   };
 
-  // SVG 좌표 계산 함수
-  const generateChartPath = (values, max) => {
-    if (!values || !values.length || !max || max <= 0) return '';
-
-    const width = 700; // SVG 내부 차트 영역 너비
-    const height = 160; // SVG 내부 차트 영역 높이
-    const padding = 50;
-    const stepX = width / (values.length - 1);
-
-    return values
-      .map((value, index) => {
-        // 안전한 숫자 변환
-        const safeValue = isNaN(value) || !isFinite(value) ? 0 : Number(value);
-        const safeMax =
-          isNaN(max) || !isFinite(max) || max <= 0 ? 100 : Number(max);
-
-        const x = padding + index * stepX;
-        const y = height - (safeValue / safeMax) * height + 40; // 40은 상단 패딩
-
-        // 좌표가 유효한 숫자인지 확인
-        const safeX = isNaN(x) || !isFinite(x) ? padding : x;
-        const safeY = isNaN(y) || !isFinite(y) ? height + 40 : y;
-
-        return `${index === 0 ? 'M' : 'L'}${safeX},${safeY}`;
-      })
-      .join(' ');
-  };
-
-  // 탭별 통계 카드 생성
-  const getStatsForTab = () => {
+  // 현재 탭에 따른 통계 데이터 반환
+  const getCurrentStats = () => {
     switch (activeMainTab) {
       case '회원현황':
-        return [
-          {
-            title: '총 회원 수',
-            value: stats.users ? formatNumber(stats.users.totalUsers) : '0',
-            subValue: stats.users
-              ? `신규: ${formatNumber(stats.users.signupCount)}명\n탈퇴: ${formatNumber(stats.users.withdrawCount)}명`
-              : '',
-            icon: (
-              <svg
-                className="w-5 h-5 text-blue-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z" />
-              </svg>
-            ),
-            iconBg: 'bg-blue-100',
-          },
-          {
-            title: '신규 가입자',
-            value: stats.users ? formatNumber(stats.users.signupCount) : '0',
-            subValue: `${selectedYear}년 ${selectedMonth}월`,
-            icon: (
-              <svg
-                className="w-5 h-5 text-green-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-green-100',
-          },
-          {
-            title: '탈퇴율',
-            value: stats.users ? formatPercent(stats.users.withdrawRate) : '0%',
-            subValue: stats.users
-              ? `${selectedYear}년 ${selectedMonth}월\n탈퇴: ${formatNumber(stats.users.withdrawCount)}명`
-              : '',
-            icon: (
-              <svg
-                className="w-5 h-5 text-red-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-red-100',
-          },
-          {
-            title: '휴면 회원',
-            value: stats.users
-              ? formatNumber(stats.users.inactiveUserCount || 0)
-              : '0',
-            subValue: stats.users
-              ? `${selectedYear}년 ${selectedMonth}월\n비활성 회원`
-              : '',
-            icon: (
-              <svg
-                className="w-5 h-5 text-yellow-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-yellow-100',
-          },
-        ];
-
+        return userStats;
       case '정산':
-        return [
-          {
-            title: '정산 신청 수',
-            value: stats.settlements
-              ? formatNumber(stats.settlements.requestedCount)
-              : '0',
-            subValue: `${selectedYear}년 ${selectedMonth}월`,
-            icon: (
-              <svg
-                className="w-5 h-5 text-blue-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path d="M8.433 7.418c.155-.103.346-.196.567-.267v1.698a2.305 2.305 0 01-.567-.267C8.07 8.34 8 8.114 8 8c0-.114.07-.34.433-.582zM11 12.849v-1.698c.22.071.412.164.567.267.364.243.433.468.433.582 0 .114-.07.34-.433.582a2.305 2.305 0 01-.567.267z" />
-                <path
-                  fillRule="evenodd"
-                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676.662C6.602 6.234 6 7.009 6 8c0 .99.602 1.765 1.324 2.246.48.32 1.054.545 1.676.662v1.941c-.391-.127-.68-.317-.843-.504a1 1 0 10-1.51 1.31c.562.649 1.413 1.076 2.353 1.253V15a1 1 0 102 0v-.092a4.535 4.535 0 001.676-.662C13.398 13.766 14 12.991 14 12c0-.99-.602-1.765-1.324-2.246A4.535 4.535 0 0011 9.092V7.151c.391.127.68.317.843.504a1 1 0 101.511-1.31c-.563-.649-1.413-1.076-2.354-1.253V5z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-blue-100',
-          },
-          {
-            title: '정산 완료 수',
-            value: stats.settlements
-              ? formatNumber(stats.settlements.paidCount)
-              : '0',
-            subValue: `${selectedYear}년 ${selectedMonth}월`,
-            icon: (
-              <svg
-                className="w-5 h-5 text-green-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-green-100',
-          },
-          {
-            title: '정산 완료율',
-            value:
-              stats.settlements && stats.settlements.requestedCount > 0
-                ? formatPercent(
-                    (stats.settlements.paidCount /
-                      stats.settlements.requestedCount) *
-                      100
-                  )
-                : '0%',
-            subValue: '신청 대비 완료',
-            icon: (
-              <svg
-                className="w-5 h-5 text-purple-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-purple-100',
-          },
-          {
-            title: '총 예약 수',
-            value: stats.reservations
-              ? formatNumber(stats.reservations.reservationCount)
-              : '0',
-            subValue: `${selectedYear}년 ${selectedMonth}월`,
-            icon: (
-              <svg
-                className="w-5 h-5 text-blue-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-blue-100',
-          },
-        ];
-
-      case '결제': {
-        const basePaymentCards = [
-          {
-            title: '총 결제 금액',
-            value: stats.payments
-              ? formatCurrency(stats.payments.totalAmount)
-              : '₩0',
-            subValue: `${selectedYear}년 ${selectedMonth}월`,
-            icon: (
-              <svg
-                className="w-5 h-5 text-blue-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path d="M8.433 7.418c.155-.103.346-.196.567-.267v1.698a2.305 2.305 0 01-.567-.267C8.07 8.34 8 8.114 8 8c0-.114.07-.34.433-.582zM11 12.849v-1.698c.22.071.412.164.567.267.364.243.433.468.433.582 0 .114-.07.34-.433.582a2.305 2.305 0 01-.567.267z" />
-                <path
-                  fillRule="evenodd"
-                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676.662C6.602 6.234 6 7.009 6 8c0 .99.602 1.765 1.324 2.246.48.32 1.054.545 1.676.662v1.941c-.391-.127-.68-.317-.843-.504a1 1 0 10-1.51 1.31c.562.649 1.413 1.076 2.353 1.253V15a1 1 0 102 0v-.092a4.535 4.535 0 001.676-.662C13.398 13.766 14 12.991 14 12c0-.99-.602-1.765-1.324-2.246A4.535 4.535 0 0011 9.092V7.151c.391.127.68.317.843.504a1 1 0 101.511-1.31c-.563-.649-1.413-1.076-2.354-1.253V5z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-blue-100',
-          },
-          {
-            title: '취소 금액',
-            value: stats.payments
-              ? formatCurrency(stats.payments.cancelAmount)
-              : '₩0',
-            subValue: `${selectedYear}년 ${selectedMonth}월`,
-            icon: (
-              <svg
-                className="w-5 h-5 text-red-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-red-100',
-          },
-        ];
-
-        // 결제 수단별 카드 추가 (월별 조회일 때만)
-        if (stats.paymentMethods) {
-          basePaymentCards.push(
-            {
-              title: '카드 결제',
-              value: formatCurrency(stats.paymentMethods.card || 0),
-              subValue: `${selectedYear}년 ${selectedMonth}월`,
-              icon: (
-                <svg
-                  className="w-5 h-5 text-indigo-600"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                >
-                  <path d="M4 4a2 2 0 00-2 2v1h16V6a2 2 0 00-2-2H4zM18 9H2v5a2 2 0 002 2h12a2 2 0 002-2V9zM4 13a1 1 0 011-1h1a1 1 0 110 2H5a1 1 0 01-1-1zm5-1a1 1 0 100 2h1a1 1 0 100-2H9z" />
-                </svg>
-              ),
-              iconBg: 'bg-indigo-100',
-            },
-            {
-              title: '계좌이체',
-              value: formatCurrency(stats.paymentMethods.transfer || 0),
-              subValue: `${selectedYear}년 ${selectedMonth}월`,
-              icon: (
-                <svg
-                  className="w-5 h-5 text-purple-600"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                >
-                  <path d="M4 4a2 2 0 00-2 2v8a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2H4zm2 6a2 2 0 104 0 2 2 0 00-4 0zm8 0a2 2 0 11-4 0 2 2 0 014 0z" />
-                </svg>
-              ),
-              iconBg: 'bg-purple-100',
-            },
-            {
-              title: '현금 결제',
-              value: formatCurrency(stats.paymentMethods.cash || 0),
-              subValue: `${selectedYear}년 ${selectedMonth}월`,
-              icon: (
-                <svg
-                  className="w-5 h-5 text-green-600"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                >
-                  <path d="M8.433 7.418c.155-.103.346-.196.567-.267v1.698a2.305 2.305 0 01-.567-.267C8.07 8.34 8 8.114 8 8c0-.114.07-.34.433-.582zM11 12.849v-1.698c.22.071.412.164.567.267.364.243.433.468.433.582 0 .114-.07.34-.433.582a2.305 2.305 0 01-.567.267z" />
-                  <path
-                    fillRule="evenodd"
-                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-13a1 1 0 10-2 0v.092a4.535 4.535 0 00-1.676.662C6.602 6.234 6 7.009 6 8c0 .99.602 1.765 1.324 2.246.48.32 1.054.545 1.676.662v1.941c-.391-.127-.68-.317-.843-.504a1 1 0 10-1.51 1.31c.562.649 1.413 1.076 2.353 1.253V15a1 1 0 102 0v-.092a4.535 4.535 0 001.676-.662C13.398 13.766 14 12.991 14 12c0-.99-.602-1.765-1.324-2.246A4.535 4.535 0 0011 9.092V7.151c.391.127.68.317.843.504a1 1 0 101.511-1.31c-.563-.649-1.413-1.076-2.354-1.253V5z"
-                    clipRule="evenodd"
-                  />
-                </svg>
-              ),
-              iconBg: 'bg-green-100',
-            }
-          );
-        }
-
-        return basePaymentCards;
-      }
-
+        return settlementStats;
+      case '결제':
+        return paymentStats;
+      case '예약관리':
+        return reservationStats;
+      case '매니저별점':
+        return managerRatingStats;
       case '매칭':
-        return [
-          {
-            title: '성공한 매칭',
-            value: stats.matching?.success
-              ? formatNumber(stats.matching.success.successCount)
-              : '0',
-            subValue: `${selectedYear}년 ${selectedMonth}월`,
-            icon: (
-              <svg
-                className="w-5 h-5 text-green-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-green-100',
-          },
-          {
-            title: '실패한 매칭',
-            value: stats.matching?.fail
-              ? formatNumber(stats.matching.fail.failCount)
-              : '0',
-            subValue: `${selectedYear}년 ${selectedMonth}월`,
-            icon: (
-              <svg
-                className="w-5 h-5 text-red-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-red-100',
-          },
-          {
-            title: '매칭 성공률',
-            value:
-              stats.matching && stats.matching.success && stats.matching.fail
-                ? formatPercent(
-                    (stats.matching.success.successCount /
-                      (stats.matching.success.successCount +
-                        stats.matching.fail.failCount)) *
-                      100
-                  )
-                : '0%',
-            subValue: '전체 매칭 대비',
-            icon: (
-              <svg
-                className="w-5 h-5 text-blue-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M3 3a1 1 0 000 2v8a2 2 0 002 2h2.586l-1.293 1.293a1 1 0 101.414 1.414L10 15.414l2.293 2.293a1 1 0 001.414-1.414L12.414 15H15a2 2 0 002-2V5a1 1 0 100-2H3zm11.707 4.707a1 1 0 00-1.414-1.414L10 9.586 8.707 8.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-blue-100',
-          },
-          {
-            title: '총 매칭 시도',
-            value:
-              stats.matching && stats.matching.success && stats.matching.fail
-                ? formatNumber(
-                    stats.matching.success.successCount +
-                      stats.matching.fail.failCount
-                  )
-                : '0',
-            subValue: '성공+실패 합계',
-            icon: (
-              <svg
-                className="w-5 h-5 text-purple-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            ),
-            iconBg: 'bg-purple-100',
-          },
-        ];
-
-      case '예약':
-        return [
-          {
-            title: '총 예약 수',
-            value: stats.reservations
-              ? formatNumber(stats.reservations.reservationCount)
-              : '0',
-            subValue: `${selectedYear}년`,
-            icon: (
-              <svg
-                className="w-5 h-5 text-blue-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-blue-100',
-          },
-          {
-            title: '평균 처리 시간',
-            value: stats.reservations
-              ? `${stats.reservations.avgProcessingMinutes.toFixed(1)}분`
-              : '0분',
-            subValue: '예약 처리 소요시간',
-            icon: (
-              <svg
-                className="w-5 h-5 text-green-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-green-100',
-          },
-          {
-            title: '일평균 예약',
-            value: stats.reservations
-              ? formatNumber(
-                  Math.round(stats.reservations.reservationCount / 365)
-                )
-              : '0',
-            subValue: '하루 평균 예약 수',
-            icon: (
-              <svg
-                className="w-5 h-5 text-yellow-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm.707-10.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L9.414 11H13a1 1 0 100-2H9.414l1.293-1.293z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-yellow-100',
-          },
-          {
-            title: '예약 효율성',
-            value:
-              stats.reservations && stats.reservations.avgProcessingMinutes > 0
-                ? stats.reservations.avgProcessingMinutes <= 10
-                  ? '우수'
-                  : stats.reservations.avgProcessingMinutes <= 20
-                    ? '양호'
-                    : '개선필요'
-                : '데이터 없음',
-            subValue: '처리 시간 기준',
-            icon: (
-              <svg
-                className="w-5 h-5 text-indigo-600"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            ),
-            iconBg: 'bg-indigo-100',
-          },
-        ];
-
+        return matchingStats;
       default:
-        return [];
+        return null;
     }
   };
 
@@ -962,67 +253,16 @@ const Statistics = () => {
       <div className="px-4 sm:px-6 lg:px-8 py-6 bg-white">
         <div className="max-w-none space-y-6">
           {/* Header with Controls */}
-          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
-            <div className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-4">
-              {/* Year Selector */}
-              <div className="flex items-center space-x-2">
-                <label className="text-sm font-medium text-gray-700">
-                  연도:
-                </label>
-                <select
-                  value={selectedYear}
-                  onChange={(e) => setSelectedYear(parseInt(e.target.value))}
-                  className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  disabled={loading}
-                >
-                  {years.map((year) => (
-                    <option key={year} value={year}>
-                      {year}년
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Month Selector (for all tabs) */}
-              <div className="flex items-center space-x-2">
-                <label className="text-sm font-medium text-gray-700">월:</label>
-                <select
-                  value={selectedMonth}
-                  onChange={(e) => setSelectedMonth(parseInt(e.target.value))}
-                  className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  disabled={loading}
-                >
-                  {months.map((month) => (
-                    <option key={month} value={month}>
-                      {month}월
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Refresh Button */}
-              <button
-                onClick={loadAllStats}
-                disabled={loading}
-                className="px-4 py-2 text-sm text-black bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 flex items-center space-x-2"
-              >
-                <svg
-                  className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-                  />
-                </svg>
-                <span>{loading ? '로딩 중...' : '새로고침'}</span>
-              </button>
-            </div>
-          </div>
+          <DateSelector
+            selectedYear={selectedYear}
+            selectedMonth={selectedMonth}
+            selectedDay={selectedDay}
+            onYearChange={setSelectedYear}
+            onMonthChange={setSelectedMonth}
+            onDayChange={setSelectedDay}
+            onRefresh={loadStats}
+            loading={loading}
+          />
 
           {/* Error Message */}
           {error && (
@@ -1047,7 +287,7 @@ const Statistics = () => {
                   </h3>
                   <p className="text-sm text-red-700 mt-1">{error}</p>
                   <button
-                    onClick={loadAllStats}
+                    onClick={loadStats}
                     className="mt-2 text-sm text-red-800 underline hover:no-underline"
                   >
                     다시 시도
@@ -1058,671 +298,41 @@ const Statistics = () => {
           )}
 
           {/* Main Tabs */}
-          <div className="w-full bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
-            <div
-              className="flex overflow-x-auto bg-white"
-              style={{ backgroundColor: 'white' }}
-            >
-              {mainTabs.map((tab) => (
-                <button
-                  key={tab}
-                  onClick={() => setActiveMainTab(tab.split(' ')[0])}
-                  className={`px-4 sm:px-6 py-4 text-sm font-medium transition-all duration-200 whitespace-nowrap ${
-                    activeMainTab === tab.split(' ')[0]
-                      ? 'text-blue-600 border-b-2 border-blue-500 bg-white'
-                      : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50 border-b-2 border-transparent bg-white'
-                  }`}
-                  style={{ backgroundColor: 'white' }}
-                  disabled={loading}
-                >
-                  {tab}
-                </button>
+          <TabNavigation
+            activeTab={activeMainTab}
+            onTabChange={setActiveMainTab}
+            loading={loading}
+          />
+
+          <div className="w-full p-6">
+            {/* Stats Grid */}
+            <div className="w-full grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mb-6">
+              {getCurrentStatsCards().map((stat, index) => (
+                <StatCard
+                  key={index}
+                  title={stat.title}
+                  value={stat.value}
+                  subValue={stat.subValue}
+                  icon={stat.icon}
+                  iconBg={stat.iconBg}
+                  loading={loading}
+                />
               ))}
             </div>
 
-            {/* 구분선 */}
-            <div className="border-b border-gray-200 bg-white"></div>
+            {/* Chart Section */}
+            <ChartSection
+              activeTab={activeMainTab}
+              stats={getCurrentStats()}
+              loading={loading}
+            />
 
-            <div className="w-full p-6">
-              {/* Stats Grid */}
-              <div className="w-full grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-6 mb-6">
-                {getStatsForTab().map((stat, index) => (
-                  <StatCard
-                    key={index}
-                    title={stat.title}
-                    value={stat.value}
-                    subValue={stat.subValue}
-                    icon={stat.icon}
-                    iconBg={stat.iconBg}
-                    loading={loading}
-                  />
-                ))}
-              </div>
-
-              {/* Chart Section */}
-              <div className="w-full bg-white rounded-lg border border-gray-200 p-6">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-4">
-                  <h3 className="text-lg font-semibold text-gray-900">
-                    {activeMainTab === '회원현황' && '회원 증가 추이'}
-                    {activeMainTab === '정산' && '정산 처리 추이'}
-                    {activeMainTab === '결제' && '결제 금액 추이'}
-                    {activeMainTab === '매칭' && '매칭 성공률 추이'}
-                    {activeMainTab === '예약' && '예약 건수 추이'}
-                  </h3>
-                  <div className="flex space-x-2">
-                    {timeTabs.map((tab) => (
-                      <button
-                        key={tab}
-                        onClick={() => setActiveTimeTab(tab)}
-                        className={`px-3 py-1 text-sm rounded-lg transition-colors ${
-                          activeTimeTab === tab
-                            ? 'text-black bg-blue-600'
-                            : 'text-gray-600 bg-gray-100 hover:bg-gray-200'
-                        }`}
-                        disabled={loading}
-                      >
-                        {tab}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Chart */}
-                <div className="w-full h-64 lg:h-80 bg-gradient-to-r from-blue-50 to-blue-100 rounded-lg flex items-center justify-center relative chart-container">
-                  {loading ? (
-                    <div className="flex items-center space-x-2">
-                      <div className="w-6 h-6 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
-                      <span className="text-gray-600">
-                        차트 데이터 로딩 중...
-                      </span>
-                    </div>
-                  ) : (
-                    (() => {
-                      const chartData = getChartData();
-                      const { values, max, labels } = chartData;
-
-                      if (!values.length) {
-                        return (
-                          <div className="text-gray-500 text-center">
-                            <div className="text-lg font-medium mb-2">
-                              데이터 없음
-                            </div>
-                            <div className="text-sm">
-                              통계 데이터를 불러올 수 없습니다.
-                            </div>
-                          </div>
-                        );
-                      }
-
-                      const chartPath = generateChartPath(values, max);
-                      const fillPath = chartPath + ' L750,200 L50,200 Z';
-
-                      return (
-                        <>
-                          <svg
-                            viewBox="0 0 800 200"
-                            className="w-full h-full max-w-full"
-                          >
-                            <defs>
-                              <linearGradient
-                                id="chartGradient"
-                                x1="0%"
-                                y1="0%"
-                                x2="0%"
-                                y2="100%"
-                              >
-                                <stop
-                                  offset="0%"
-                                  style={{
-                                    stopColor: '#3B82F6',
-                                    stopOpacity: 0.8,
-                                  }}
-                                />
-                                <stop
-                                  offset="100%"
-                                  style={{
-                                    stopColor: '#3B82F6',
-                                    stopOpacity: 0.1,
-                                  }}
-                                />
-                              </linearGradient>
-                            </defs>
-
-                            {/* Chart line */}
-                            <path
-                              d={chartPath}
-                              fill="none"
-                              stroke="#3B82F6"
-                              strokeWidth="3"
-                            />
-                            <path d={fillPath} fill="url(#chartGradient)" />
-
-                            {/* Data points */}
-                            {values.map((value, index) => {
-                              // 안전한 좌표 계산
-                              const safeValue =
-                                isNaN(value) || !isFinite(value)
-                                  ? 0
-                                  : Number(value);
-                              const safeMax =
-                                isNaN(max) || !isFinite(max) || max <= 0
-                                  ? 100
-                                  : Number(max);
-
-                              const x =
-                                50 + index * (700 / (values.length - 1));
-                              const y = 160 - (safeValue / safeMax) * 160 + 40;
-
-                              // 좌표가 유효한 숫자인지 확인
-                              const safeX = isNaN(x) || !isFinite(x) ? 50 : x;
-                              const safeY = isNaN(y) || !isFinite(y) ? 200 : y;
-
-                              return (
-                                <circle
-                                  key={index}
-                                  cx={safeX}
-                                  cy={safeY}
-                                  r="4"
-                                  fill="#3B82F6"
-                                  stroke="white"
-                                  strokeWidth="2"
-                                />
-                              );
-                            })}
-                          </svg>
-
-                          {/* X-axis labels */}
-                          <div className="absolute bottom-4 left-6 flex justify-between w-full pr-12 text-sm text-gray-600">
-                            {labels.slice(0, 5).map((label, index) => (
-                              <span key={index}>{label}</span>
-                            ))}
-                          </div>
-                        </>
-                      );
-                    })()
-                  )}
-                </div>
-              </div>
-
-              {/* Distribution Chart */}
-              <div className="w-full mt-6 bg-white rounded-lg border border-gray-200 p-6">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-6 gap-4">
-                  <h3 className="text-lg font-semibold text-gray-900">
-                    {activeMainTab === '회원현황' && '회원 분포'}
-                    {activeMainTab === '정산' && '정산 상태 분포'}
-                    {activeMainTab === '결제' && '결제 수단 분포'}
-                    {activeMainTab === '매칭' && '매칭 결과 분포'}
-                    {activeMainTab === '예약' && '예약 처리 효율성'}
-                  </h3>
-                  {!loading && (
-                    <div className="flex flex-col sm:flex-row items-start sm:items-center space-y-2 sm:space-y-0 sm:space-x-4 text-sm">
-                      {activeMainTab === '회원현황' && stats.users && (
-                        <>
-                          <div className="flex items-center">
-                            <div className="w-3 h-3 bg-blue-500 rounded-full mr-2"></div>
-                            <span>활성 회원</span>
-                            <span className="ml-2 font-semibold text-blue-600">
-                              {formatNumber(
-                                stats.users.totalUsers -
-                                  stats.users.dormantCount
-                              )}
-                              명
-                            </span>
-                          </div>
-                          <div className="flex items-center">
-                            <div className="w-3 h-3 bg-yellow-500 rounded-full mr-2"></div>
-                            <span>휴면 회원</span>
-                            <span className="ml-2 font-semibold text-yellow-600">
-                              {formatNumber(stats.users.inactiveUserCount || 0)}
-                              명
-                            </span>
-                          </div>
-                        </>
-                      )}
-                      {activeMainTab === '정산' && stats.settlements && (
-                        <>
-                          <div className="flex items-center">
-                            <div className="w-3 h-3 bg-green-500 rounded-full mr-2"></div>
-                            <span>완료</span>
-                            <span className="ml-2 font-semibold text-green-600">
-                              {formatNumber(stats.settlements.paidCount)}건
-                            </span>
-                          </div>
-                          <div className="flex items-center">
-                            <div className="w-3 h-3 bg-blue-500 rounded-full mr-2"></div>
-                            <span>대기</span>
-                            <span className="ml-2 font-semibold text-blue-600">
-                              {formatNumber(
-                                stats.settlements.requestedCount -
-                                  stats.settlements.paidCount
-                              )}
-                              건
-                            </span>
-                          </div>
-                        </>
-                      )}
-                      {activeMainTab === '결제' && (
-                        <>
-                          {stats.paymentMethods &&
-                          (stats.paymentMethods.card || 0) +
-                            (stats.paymentMethods.transfer || 0) +
-                            (stats.paymentMethods.cash || 0) >
-                            0 ? (
-                            <>
-                              <div className="flex items-center">
-                                <div className="w-3 h-3 bg-blue-500 rounded-full mr-2"></div>
-                                <span>카드</span>
-                                <span className="ml-2 font-semibold text-blue-600">
-                                  {formatCurrency(
-                                    stats.paymentMethods.card || 0
-                                  )}
-                                </span>
-                              </div>
-                              <div className="flex items-center">
-                                <div className="w-3 h-3 bg-purple-500 rounded-full mr-2"></div>
-                                <span>계좌이체</span>
-                                <span className="ml-2 font-semibold text-purple-600">
-                                  {formatCurrency(
-                                    stats.paymentMethods.transfer || 0
-                                  )}
-                                </span>
-                              </div>
-                              <div className="flex items-center">
-                                <div className="w-3 h-3 bg-yellow-500 rounded-full mr-2"></div>
-                                <span>현금</span>
-                                <span className="ml-2 font-semibold text-yellow-600">
-                                  {formatCurrency(
-                                    stats.paymentMethods.cash || 0
-                                  )}
-                                </span>
-                              </div>
-                            </>
-                          ) : stats.payments &&
-                            (stats.payments.totalAmount || 0) > 0 ? (
-                            <div className="text-sm text-gray-500">
-                              {selectedYear}년 {selectedMonth}월 결제 수단별
-                              데이터 없음 (총액:{' '}
-                              {formatCurrency(stats.payments.totalAmount)})
-                            </div>
-                          ) : (
-                            <div className="text-sm text-gray-500">
-                              {selectedYear}년 {selectedMonth}월 결제 데이터
-                              없음
-                            </div>
-                          )}
-                        </>
-                      )}
-                      {activeMainTab === '매칭' &&
-                        stats.matching &&
-                        stats.matching.success &&
-                        stats.matching.fail && (
-                          <>
-                            <div className="flex items-center">
-                              <div className="w-3 h-3 bg-green-500 rounded-full mr-2"></div>
-                              <span>성공</span>
-                              <span className="ml-2 font-semibold text-green-600">
-                                {formatNumber(
-                                  stats.matching.success.successCount
-                                )}
-                                건
-                              </span>
-                            </div>
-                            <div className="flex items-center">
-                              <div className="w-3 h-3 bg-red-500 rounded-full mr-2"></div>
-                              <span>실패</span>
-                              <span className="ml-2 font-semibold text-red-600">
-                                {formatNumber(stats.matching.fail.failCount)}건
-                              </span>
-                            </div>
-                          </>
-                        )}
-                      {activeMainTab === '예약' && stats.reservations && (
-                        <>
-                          <div className="flex items-center">
-                            <div className="w-16 sm:w-20 text-sm text-gray-600">
-                              평균 처리시간
-                            </div>
-                            <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                              <div
-                                className="bg-green-500 h-4 rounded-full"
-                                style={{
-                                  width: `${stats.reservations.avgProcessingMinutes <= 10 ? 80 : stats.reservations.avgProcessingMinutes <= 20 ? 60 : 30}%`,
-                                }}
-                              ></div>
-                            </div>
-                            <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                              {stats.reservations.avgProcessingMinutes.toFixed(
-                                1
-                              )}
-                              분
-                            </div>
-                          </div>
-                          <div className="flex items-center">
-                            <div className="w-16 sm:w-20 text-sm text-gray-600">
-                              일평균 예약
-                            </div>
-                            <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                              <div
-                                className="bg-blue-500 h-4 rounded-full"
-                                style={{
-                                  width: `${Math.min((Math.round(stats.reservations.reservationCount / 365) / 50) * 100, 100)}%`,
-                                }}
-                              ></div>
-                            </div>
-                            <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                              {formatNumber(
-                                Math.round(
-                                  stats.reservations.reservationCount / 365
-                                )
-                              )}
-                              건/일
-                            </div>
-                          </div>
-                        </>
-                      )}
-                    </div>
-                  )}
-                </div>
-
-                {/* Bar chart representation */}
-                <div className="space-y-4 w-full">
-                  {loading ? (
-                    <>
-                      <div className="flex items-center">
-                        <div className="w-16 h-4 bg-gray-200 rounded animate-pulse mr-4"></div>
-                        <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4 animate-pulse"></div>
-                        <div className="w-12 h-4 bg-gray-200 rounded animate-pulse"></div>
-                      </div>
-                      <div className="flex items-center">
-                        <div className="w-16 h-4 bg-gray-200 rounded animate-pulse mr-4"></div>
-                        <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4 animate-pulse"></div>
-                        <div className="w-12 h-4 bg-gray-200 rounded animate-pulse"></div>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      {activeMainTab === '회원현황' && stats.users && (
-                        <>
-                          <div className="flex items-center">
-                            <div className="w-16 sm:w-20 text-sm text-gray-600">
-                              활성 회원
-                            </div>
-                            <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                              <div
-                                className="bg-blue-500 h-4 rounded-full"
-                                style={{
-                                  width: `${((stats.users.totalUsers - (stats.users.inactiveUserCount || 0)) / stats.users.totalUsers) * 100}%`,
-                                }}
-                              ></div>
-                            </div>
-                            <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                              {formatPercent(
-                                ((stats.users.totalUsers -
-                                  (stats.users.inactiveUserCount || 0)) /
-                                  stats.users.totalUsers) *
-                                  100
-                              )}
-                            </div>
-                          </div>
-                          <div className="flex items-center">
-                            <div className="w-16 sm:w-20 text-sm text-gray-600">
-                              휴면 회원
-                            </div>
-                            <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                              <div
-                                className="bg-yellow-500 h-4 rounded-full"
-                                style={{
-                                  width: `${((stats.users.inactiveUserCount || 0) / stats.users.totalUsers) * 100}%`,
-                                }}
-                              ></div>
-                            </div>
-                            <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                              {formatPercent(
-                                ((stats.users.inactiveUserCount || 0) /
-                                  stats.users.totalUsers) *
-                                  100
-                              )}
-                            </div>
-                          </div>
-                        </>
-                      )}
-                      {activeMainTab === '정산' && stats.settlements && (
-                        <>
-                          <div className="flex items-center">
-                            <div className="w-16 sm:w-20 text-sm text-gray-600">
-                              완료
-                            </div>
-                            <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                              <div
-                                className="bg-green-500 h-4 rounded-full"
-                                style={{
-                                  width: `${(stats.settlements.paidCount / stats.settlements.requestedCount) * 100}%`,
-                                }}
-                              ></div>
-                            </div>
-                            <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                              {formatPercent(
-                                (stats.settlements.paidCount /
-                                  stats.settlements.requestedCount) *
-                                  100
-                              )}
-                            </div>
-                          </div>
-                          <div className="flex items-center">
-                            <div className="w-16 sm:w-20 text-sm text-gray-600">
-                              대기
-                            </div>
-                            <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                              <div
-                                className="bg-blue-500 h-4 rounded-full"
-                                style={{
-                                  width: `${((stats.settlements.requestedCount - stats.settlements.paidCount) / stats.settlements.requestedCount) * 100}%`,
-                                }}
-                              ></div>
-                            </div>
-                            <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                              {formatPercent(
-                                ((stats.settlements.requestedCount -
-                                  stats.settlements.paidCount) /
-                                  stats.settlements.requestedCount) *
-                                  100
-                              )}
-                            </div>
-                          </div>
-                        </>
-                      )}
-                      {activeMainTab === '결제' && (
-                        <>
-                          {stats.paymentMethods &&
-                          (stats.paymentMethods.card || 0) +
-                            (stats.paymentMethods.transfer || 0) +
-                            (stats.paymentMethods.cash || 0) >
-                            0 ? (
-                            <>
-                              <div className="flex items-center">
-                                <div className="w-16 sm:w-20 text-sm text-gray-600">
-                                  카드
-                                </div>
-                                <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                                  <div
-                                    className="bg-blue-500 h-4 rounded-full"
-                                    style={{
-                                      width: `${((stats.paymentMethods.card || 0) / ((stats.paymentMethods.card || 0) + (stats.paymentMethods.transfer || 0) + (stats.paymentMethods.cash || 0))) * 100}%`,
-                                    }}
-                                  ></div>
-                                </div>
-                                <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                                  {formatPercent(
-                                    ((stats.paymentMethods.card || 0) /
-                                      ((stats.paymentMethods.card || 0) +
-                                        (stats.paymentMethods.transfer || 0) +
-                                        (stats.paymentMethods.cash || 0))) *
-                                      100
-                                  )}
-                                </div>
-                              </div>
-                              <div className="flex items-center">
-                                <div className="w-16 sm:w-20 text-sm text-gray-600">
-                                  계좌이체
-                                </div>
-                                <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                                  <div
-                                    className="bg-purple-500 h-4 rounded-full"
-                                    style={{
-                                      width: `${((stats.paymentMethods.transfer || 0) / ((stats.paymentMethods.card || 0) + (stats.paymentMethods.transfer || 0) + (stats.paymentMethods.cash || 0))) * 100}%`,
-                                    }}
-                                  ></div>
-                                </div>
-                                <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                                  {formatPercent(
-                                    ((stats.paymentMethods.transfer || 0) /
-                                      ((stats.paymentMethods.card || 0) +
-                                        (stats.paymentMethods.transfer || 0) +
-                                        (stats.paymentMethods.cash || 0))) *
-                                      100
-                                  )}
-                                </div>
-                              </div>
-                              <div className="flex items-center">
-                                <div className="w-16 sm:w-20 text-sm text-gray-600">
-                                  현금
-                                </div>
-                                <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                                  <div
-                                    className="bg-yellow-500 h-4 rounded-full"
-                                    style={{
-                                      width: `${((stats.paymentMethods.cash || 0) / ((stats.paymentMethods.card || 0) + (stats.paymentMethods.transfer || 0) + (stats.paymentMethods.cash || 0))) * 100}%`,
-                                    }}
-                                  ></div>
-                                </div>
-                                <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                                  {formatPercent(
-                                    ((stats.paymentMethods.cash || 0) /
-                                      ((stats.paymentMethods.card || 0) +
-                                        (stats.paymentMethods.transfer || 0) +
-                                        (stats.paymentMethods.cash || 0))) *
-                                      100
-                                  )}
-                                </div>
-                              </div>
-                            </>
-                          ) : stats.payments &&
-                            (stats.payments.totalAmount || 0) > 0 ? (
-                            <div className="flex items-center justify-center py-8">
-                              <div className="text-sm text-gray-500">
-                                {selectedYear}년 {selectedMonth}월 결제 수단별
-                                데이터 없음 (총액:{' '}
-                                {formatCurrency(stats.payments.totalAmount)})
-                              </div>
-                            </div>
-                          ) : (
-                            <div className="flex items-center justify-center py-8">
-                              <div className="text-sm text-gray-500">
-                                {selectedYear}년 {selectedMonth}월 결제 데이터
-                                없음
-                              </div>
-                            </div>
-                          )}
-                        </>
-                      )}
-                      {activeMainTab === '매칭' &&
-                        stats.matching &&
-                        stats.matching.success &&
-                        stats.matching.fail && (
-                          <>
-                            <div className="flex items-center">
-                              <div className="w-16 sm:w-20 text-sm text-gray-600">
-                                성공
-                              </div>
-                              <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                                <div
-                                  className="bg-green-500 h-4 rounded-full"
-                                  style={{
-                                    width: `${(stats.matching.success.successCount / (stats.matching.success.successCount + stats.matching.fail.failCount)) * 100}%`,
-                                  }}
-                                ></div>
-                              </div>
-                              <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                                {formatPercent(
-                                  (stats.matching.success.successCount /
-                                    (stats.matching.success.successCount +
-                                      stats.matching.fail.failCount)) *
-                                    100
-                                )}
-                              </div>
-                            </div>
-                            <div className="flex items-center">
-                              <div className="w-16 sm:w-20 text-sm text-gray-600">
-                                실패
-                              </div>
-                              <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                                <div
-                                  className="bg-red-500 h-4 rounded-full"
-                                  style={{
-                                    width: `${(stats.matching.fail.failCount / (stats.matching.success.successCount + stats.matching.fail.failCount)) * 100}%`,
-                                  }}
-                                ></div>
-                              </div>
-                              <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                                {formatPercent(
-                                  (stats.matching.fail.failCount /
-                                    (stats.matching.success.successCount +
-                                      stats.matching.fail.failCount)) *
-                                    100
-                                )}
-                              </div>
-                            </div>
-                          </>
-                        )}
-                      {activeMainTab === '예약' && stats.reservations && (
-                        <>
-                          <div className="flex items-center">
-                            <div className="w-16 sm:w-20 text-sm text-gray-600">
-                              평균 처리시간
-                            </div>
-                            <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                              <div
-                                className="bg-green-500 h-4 rounded-full"
-                                style={{
-                                  width: `${stats.reservations.avgProcessingMinutes <= 10 ? 80 : stats.reservations.avgProcessingMinutes <= 20 ? 60 : 30}%`,
-                                }}
-                              ></div>
-                            </div>
-                            <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                              {stats.reservations.avgProcessingMinutes.toFixed(
-                                1
-                              )}
-                              분
-                            </div>
-                          </div>
-                          <div className="flex items-center">
-                            <div className="w-16 sm:w-20 text-sm text-gray-600">
-                              일평균 예약
-                            </div>
-                            <div className="flex-1 bg-gray-200 rounded-full h-4 mr-4">
-                              <div
-                                className="bg-blue-500 h-4 rounded-full"
-                                style={{
-                                  width: `${Math.min((Math.round(stats.reservations.reservationCount / 365) / 50) * 100, 100)}%`,
-                                }}
-                              ></div>
-                            </div>
-                            <div className="w-12 sm:w-16 text-sm text-gray-900 font-medium">
-                              {formatNumber(
-                                Math.round(
-                                  stats.reservations.reservationCount / 365
-                                )
-                              )}
-                              건/일
-                            </div>
-                          </div>
-                        </>
-                      )}
-                    </>
-                  )}
-                </div>
-              </div>
-            </div>
+            {/* Distribution Chart */}
+            <DistributionChart
+              activeTab={activeMainTab}
+              stats={getCurrentStats()}
+              loading={loading}
+            />
           </div>
         </div>
       </div>

--- a/src/features/admin/services/statisticsAPI.js
+++ b/src/features/admin/services/statisticsAPI.js
@@ -1,0 +1,129 @@
+/**
+ * 공통 API 호출 함수
+ * @param {string} endpoint - API 엔드포인트
+ * @param {number} year - 연도
+ * @param {number|null} month - 월 (optional)
+ * @param {number|null} day - 일 (optional)
+ * @returns {Promise<Object>} API 응답 데이터
+ */
+const fetchStatistics = async (endpoint, year, month, day) => {
+  try {
+    const token = localStorage.getItem('accessToken');
+    let url = `/api/v1/admin/statistics/${endpoint}?year=${year}`;
+
+    if (month) {
+      url += `&month=${month}`;
+    }
+    if (day) {
+      url += `&day=${day}`;
+    }
+
+    console.log(`🔗 ${endpoint} 통계 API 호출 URL:`, url);
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      console.log(`✅ ${endpoint} 통계 API 응답 데이터:`, data);
+
+      // CommonApiResponse 구조 처리
+      if (data && data.data) {
+        return data.data;
+      } else {
+        return data;
+      }
+    } else {
+      const errorText = await response.text();
+      console.error(`❌ ${endpoint} 통계 API 오류:`, {
+        status: response.status,
+        error: errorText,
+      });
+      throw new Error(`${endpoint} 통계 API 오류: ${response.status}`);
+    }
+  } catch (err) {
+    console.error(`💥 ${endpoint} 통계 조회 실패:`, err);
+    throw err;
+  }
+};
+
+/**
+ * 전체 통계 API 호출
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Promise<Object>} 전체 통계 데이터
+ */
+export const fetchAllStats = async (year, month, day) => {
+  return await fetchStatistics('all', year, month, day);
+};
+
+/**
+ * 회원 통계 API 호출
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Promise<Object>} 회원 통계 데이터
+ */
+export const fetchUserStats = async (year, month, day) => {
+  return await fetchStatistics('users', year, month, day);
+};
+
+/**
+ * 정산 통계 API 호출
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Promise<Object>} 정산 통계 데이터
+ */
+export const fetchSettlementStats = async (year, month, day) => {
+  return await fetchStatistics('settlements', year, month, day);
+};
+
+/**
+ * 결제 통계 API 호출
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Promise<Object>} 결제 통계 데이터
+ */
+export const fetchPaymentStats = async (year, month, day) => {
+  return await fetchStatistics('payments', year, month, day);
+};
+
+/**
+ * 예약 통계 API 호출
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Promise<Object>} 예약 통계 데이터
+ */
+export const fetchReservationStats = async (year, month, day) => {
+  return await fetchStatistics('reservations', year, month, day);
+};
+
+/**
+ * 매칭 통계 API 호출
+ * @param {number} year - 연도
+ * @param {number|null} month - 월
+ * @param {number|null} day - 일
+ * @returns {Promise<Object>} 매칭 통계 데이터
+ */
+/**
+ * 매니저 평점 통계 조회
+ * @param {number} year - 연도
+ * @param {number|null} month - 월 (optional)
+ * @param {number|null} day - 일 (optional)
+ * @returns {Promise<Object>} 매니저 평점 통계 데이터
+ */
+export const fetchManagerRatingStats = async (year, month, day) => {
+  return await fetchStatistics('manager-ratings', year, month, day);
+};
+
+export const fetchMatchingStats = async (year, month, day) => {
+  return await fetchStatistics('matching', year, month, day);
+};

--- a/src/features/admin/services/statisticsAPI.js
+++ b/src/features/admin/services/statisticsAPI.js
@@ -42,7 +42,18 @@ const fetchStatistics = async (endpoint, year, month, day) => {
       console.error(`❌ ${endpoint} 통계 API 오류:`, {
         status: response.status,
         error: errorText,
+        url: url,
+        requestDate: { year, month, day },
       });
+
+      // 404 오류의 경우 더 구체적인 메시지 제공
+      if (response.status === 404) {
+        const dateStr = `${year}년${month ? ` ${month}월` : ''}${day ? ` ${day}일` : ''}`;
+        throw new Error(
+          `${endpoint} 통계 API 오류: 404 - ${dateStr} 데이터가 존재하지 않습니다.`
+        );
+      }
+
       throw new Error(`${endpoint} 통계 API 오류: ${response.status}`);
     }
   } catch (err) {

--- a/src/features/admin/utils/statisticsUtils.js
+++ b/src/features/admin/utils/statisticsUtils.js
@@ -127,86 +127,188 @@ export const generateChartData = (
   selectedYear,
   selectedMonth
 ) => {
-  // 라벨 생성 (월별 또는 일별)
-  const labels = generateDailyLabels(selectedYear, selectedMonth);
-  const dataCount = labels.length;
-
-  if (activeTab === '회원현황' && stats) {
-    const totalUsers = Number(stats.totalUsers) || 100;
-    const signupCount = Number(stats.signupCount) || 0;
-    const withdrawCount = Number(stats.withdrawCount) || 0;
-    const maxValue = Math.max(totalUsers, 100);
-
-    return {
-      values: generateDailyValues(totalUsers, dataCount),
-      max: maxValue * 1.2,
-      labels,
-      mainValue: totalUsers,
-      subValues: [signupCount, withdrawCount],
-    };
-  } else if (activeTab === '정산' && stats) {
-    const requestedCount = Number(stats.requestedCount) || 10;
-    const paidCount = Number(stats.paidCount) || 0;
-    const maxValue = Math.max(requestedCount, 10);
-
-    return {
-      values: generateDailyValues(paidCount, dataCount),
-      max: maxValue * 1.2,
-      labels,
-      mainValue: requestedCount,
-      subValues: [paidCount, requestedCount - paidCount],
-    };
-  } else if (activeTab === '결제' && stats) {
-    const totalAmount = Number(stats.totalAmount) || 1000;
-    const cancelAmount = Number(stats.cancelAmount) || 0;
-    const maxValue = Math.max(totalAmount, 1000);
-
-    return {
-      values: generateDailyValues(totalAmount, dataCount),
-      max: maxValue * 1.2,
-      labels,
-      mainValue: totalAmount,
-      subValues: [totalAmount - cancelAmount, cancelAmount],
-    };
-  } else if (activeTab === '예약관리' && stats) {
-    const reservationCount = Number(stats.reservationCount) || 100;
-    const cancelledCount = Number(stats.cancelledCount) || 0;
-    const maxValue = Math.max(reservationCount, 100);
-
-    return {
-      values: generateDailyValues(reservationCount, dataCount),
-      max: maxValue * 1.2,
-      labels,
-      mainValue: reservationCount,
-      subValues: [reservationCount - cancelledCount, cancelledCount],
-    };
-  } else if (activeTab === '매니저별점' && stats) {
-    const avgRating = Number(stats.avgRating) || 4.0;
-    const reviewCount = Number(stats.reviewCount) || 100;
-    const maxValue = Math.max(avgRating, 5);
-
-    return {
-      values: generateDailyValues(avgRating, dataCount),
-      max: maxValue * 1.2,
-      labels,
-      mainValue: avgRating,
-      subValues: [reviewCount],
-    };
-  } else if (activeTab === '매칭' && stats) {
-    const totalCount = Number(stats.totalCount) || 100;
-    const successCount = Number(stats.successCount) || 0;
-    const maxValue = Math.max(totalCount, 100);
-
-    return {
-      values: generateDailyValues(totalCount, dataCount),
-      max: maxValue * 1.2,
-      labels,
-      mainValue: totalCount,
-      subValues: [successCount, stats.failCount],
-    };
+  // 통계 데이터가 없거나 유효하지 않으면 빈 데이터 반환
+  if (!stats) {
+    return { values: [], max: 100, labels: [], hasData: false };
   }
 
-  return { values: [], max: 100, labels: [] };
+  // 현재 날짜 기준으로 실제 데이터가 있는 날짜만 처리
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth() + 1;
+  const currentDay = today.getDate();
+
+  // 선택된 월이 현재 월보다 미래이거나, 같은 월에서 미래 날짜인 경우 데이터 없음 처리
+  if (selectedMonth) {
+    if (
+      selectedYear > currentYear ||
+      (selectedYear === currentYear && selectedMonth > currentMonth)
+    ) {
+      return { values: [], max: 100, labels: [], hasData: false };
+    }
+
+    // 현재 월인 경우 오늘까지만 라벨 생성
+    const isCurrentMonth =
+      selectedYear === currentYear && selectedMonth === currentMonth;
+    const maxDay = isCurrentMonth
+      ? currentDay
+      : getDaysInMonth(selectedYear, selectedMonth);
+
+    const labels = Array.from({ length: maxDay }, (_, i) => `${i + 1}일`);
+
+    // 실제 데이터가 있는지 확인하고 단일 값만 반환 (더미 데이터 생성하지 않음)
+    if (activeTab === '회원현황') {
+      const totalUsers = Number(stats.totalUsers) || 0;
+      const signupCount = Number(stats.signupCount) || 0;
+      const withdrawCount = Number(stats.withdrawCount) || 0;
+
+      if (totalUsers === 0 && signupCount === 0 && withdrawCount === 0) {
+        return { values: [], max: 100, labels: [], hasData: false };
+      }
+
+      // 실제 값 하나만 표시 (오늘의 값)
+      const values = [totalUsers];
+      const maxValue = Math.max(totalUsers, 100);
+
+      return {
+        values,
+        max: maxValue * 1.2,
+        labels: labels.slice(-1), // 마지막 날짜만
+        mainValue: totalUsers,
+        subValues: [signupCount, withdrawCount],
+        hasData: true,
+      };
+    } else if (activeTab === '정산') {
+      const requestedCount = Number(stats.requestedCount) || 0;
+      const paidCount = Number(stats.paidCount) || 0;
+
+      if (requestedCount === 0 && paidCount === 0) {
+        return { values: [], max: 100, labels: [], hasData: false };
+      }
+
+      const values = [paidCount];
+      const maxValue = Math.max(requestedCount, 10);
+
+      return {
+        values,
+        max: maxValue * 1.2,
+        labels: labels.slice(-1),
+        mainValue: requestedCount,
+        subValues: [paidCount, requestedCount - paidCount],
+        hasData: true,
+      };
+    } else if (activeTab === '결제') {
+      const totalAmount = Number(stats.totalAmount) || 0;
+      const cancelAmount = Number(stats.cancelAmount) || 0;
+
+      if (totalAmount === 0 && cancelAmount === 0) {
+        return { values: [], max: 100, labels: [], hasData: false };
+      }
+
+      const values = [totalAmount];
+      const maxValue = Math.max(totalAmount, 1000);
+
+      return {
+        values,
+        max: maxValue * 1.2,
+        labels: labels.slice(-1),
+        mainValue: totalAmount,
+        subValues: [totalAmount - cancelAmount, cancelAmount],
+        hasData: true,
+      };
+    } else if (activeTab === '예약관리') {
+      const reservationCount = Number(stats.reservationCount) || 0;
+      const cancelledCount = Number(stats.cancelledCount) || 0;
+
+      if (reservationCount === 0 && cancelledCount === 0) {
+        return { values: [], max: 100, labels: [], hasData: false };
+      }
+
+      const values = [reservationCount];
+      const maxValue = Math.max(reservationCount, 100);
+
+      return {
+        values,
+        max: maxValue * 1.2,
+        labels: labels.slice(-1),
+        mainValue: reservationCount,
+        subValues: [reservationCount - cancelledCount, cancelledCount],
+        hasData: true,
+      };
+    } else if (activeTab === '매니저별점') {
+      const avgRating = Number(stats.avgRating) || 0;
+      const reviewCount = Number(stats.reviewCount) || 0;
+
+      if (avgRating === 0 && reviewCount === 0) {
+        return { values: [], max: 100, labels: [], hasData: false };
+      }
+
+      const values = [avgRating];
+      const maxValue = Math.max(avgRating, 5);
+
+      return {
+        values,
+        max: maxValue * 1.2,
+        labels: labels.slice(-1),
+        mainValue: avgRating,
+        subValues: [reviewCount],
+        hasData: true,
+      };
+    } else if (activeTab === '매칭') {
+      const totalCount = Number(stats.totalCount) || 0;
+      const successCount = Number(stats.successCount) || 0;
+      const failCount = Number(stats.failCount) || 0;
+
+      if (totalCount === 0 && successCount === 0 && failCount === 0) {
+        return { values: [], max: 100, labels: [], hasData: false };
+      }
+
+      const values = [totalCount];
+      const maxValue = Math.max(totalCount, 100);
+
+      return {
+        values,
+        max: maxValue * 1.2,
+        labels: labels.slice(-1),
+        mainValue: totalCount,
+        subValues: [successCount, failCount],
+        hasData: true,
+      };
+    }
+  } else {
+    // 전체 선택 시 (월별 라벨)
+    const labels = [
+      '1월',
+      '2월',
+      '3월',
+      '4월',
+      '5월',
+      '6월',
+      '7월',
+      '8월',
+      '9월',
+      '10월',
+      '11월',
+      '12월',
+    ];
+    const currentMonthLabels = labels.slice(0, currentMonth);
+
+    // 간단한 단일 값 표시
+    if (activeTab === '회원현황') {
+      const totalUsers = Number(stats.totalUsers) || 0;
+      if (totalUsers === 0) {
+        return { values: [], max: 100, labels: [], hasData: false };
+      }
+      return {
+        values: [totalUsers],
+        max: totalUsers * 1.2,
+        labels: currentMonthLabels.slice(-1),
+        hasData: true,
+      };
+    }
+  }
+
+  return { values: [], max: 100, labels: [], hasData: false };
 };
 
 /**

--- a/src/features/admin/utils/statisticsUtils.js
+++ b/src/features/admin/utils/statisticsUtils.js
@@ -1,0 +1,283 @@
+/**
+ * 숫자 포맷팅 함수
+ * @param {number} number - 포맷팅할 숫자
+ * @returns {string} 포맷팅된 숫자 문자열
+ */
+export const formatNumber = (number) => {
+  if (!number || isNaN(number) || !isFinite(number)) return '0';
+  return Number(number).toLocaleString();
+};
+
+/**
+ * 퍼센트 포맷팅 함수
+ * @param {number} percent - 포맷팅할 퍼센트 값
+ * @returns {string} 포맷팅된 퍼센트 문자열
+ */
+export const formatPercent = (percent) => {
+  if (!percent || isNaN(percent) || !isFinite(percent)) return '0%';
+  return `${Number(percent).toFixed(1)}%`;
+};
+
+/**
+ * 금액 포맷팅 함수
+ * @param {number} amount - 포맷팅할 금액
+ * @returns {string} 포맷팅된 금액 문자열
+ */
+export const formatCurrency = (amount) => {
+  if (!amount) return '₩0';
+  return `₩${amount.toLocaleString()}`;
+};
+
+/**
+ * SVG 차트 좌표 계산 함수
+ * @param {number[]} values - 차트 값 배열
+ * @param {number} max - 최대값
+ * @returns {string} SVG 경로 문자열
+ */
+export const generateChartPath = (values, max) => {
+  if (!values || !values.length || !max || max <= 0) return '';
+
+  const width = 700;
+  const height = 160;
+  const padding = 50;
+  const stepX = width / (values.length - 1);
+
+  return values
+    .map((value, index) => {
+      const safeValue = isNaN(value) || !isFinite(value) ? 0 : Number(value);
+      const safeMax =
+        isNaN(max) || !isFinite(max) || max <= 0 ? 100 : Number(max);
+
+      const x = padding + index * stepX;
+      const y = height - (safeValue / safeMax) * height + 40;
+
+      const safeX = isNaN(x) || !isFinite(x) ? padding : x;
+      const safeY = isNaN(y) || !isFinite(y) ? height + 40 : y;
+
+      return `${index === 0 ? 'M' : 'L'}${safeX},${safeY}`;
+    })
+    .join(' ');
+};
+
+/**
+ * 차트 데이터 생성 함수
+ * @param {string} activeTab - 활성 탭
+ * @param {Object} stats - 통계 데이터
+ * @returns {Object} 차트 데이터
+ */
+export const generateChartData = (activeTab, stats) => {
+  if (activeTab === '회원현황' && stats) {
+    const totalUsers = Number(stats.totalUsers) || 100;
+    const signupCount = Number(stats.signupCount) || 0;
+    const withdrawCount = Number(stats.withdrawCount) || 0;
+    const maxValue = Math.max(totalUsers, 100);
+
+    return {
+      values: [
+        totalUsers * 0.7,
+        totalUsers * 0.75,
+        totalUsers * 0.8,
+        totalUsers * 0.85,
+        totalUsers * 0.9,
+        totalUsers * 0.95,
+        totalUsers,
+        totalUsers,
+      ],
+      max: maxValue * 1.2,
+      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      mainValue: totalUsers,
+      subValues: [signupCount, withdrawCount],
+    };
+  } else if (activeTab === '정산' && stats) {
+    const requestedCount = Number(stats.requestedCount) || 10;
+    const paidCount = Number(stats.paidCount) || 0;
+    const maxValue = Math.max(requestedCount, 10);
+
+    return {
+      values: [
+        paidCount * 0.3,
+        paidCount * 0.5,
+        paidCount * 0.65,
+        paidCount * 0.75,
+        paidCount * 0.85,
+        paidCount * 0.9,
+        paidCount * 0.95,
+        paidCount,
+      ],
+      max: maxValue * 1.2,
+      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      mainValue: requestedCount,
+      subValues: [paidCount, requestedCount - paidCount],
+    };
+  } else if (activeTab === '결제' && stats) {
+    const totalAmount = Number(stats.totalAmount) || 1000;
+    const cancelAmount = Number(stats.cancelAmount) || 0;
+    const maxValue = Math.max(totalAmount, 1000);
+
+    return {
+      values: [
+        totalAmount * 0.4,
+        totalAmount * 0.55,
+        totalAmount * 0.7,
+        totalAmount * 0.8,
+        totalAmount * 0.85,
+        totalAmount * 0.9,
+        totalAmount * 0.95,
+        totalAmount,
+      ],
+      max: maxValue * 1.2,
+      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      mainValue: totalAmount,
+      subValues: [totalAmount - cancelAmount, cancelAmount],
+    };
+  } else if (activeTab === '예약관리' && stats) {
+    const reservationCount = Number(stats.reservationCount) || 100;
+    const cancelledCount = Number(stats.cancelledCount) || 0;
+    const maxValue = Math.max(reservationCount, 100);
+
+    return {
+      values: [
+        reservationCount * 0.3,
+        reservationCount * 0.45,
+        reservationCount * 0.6,
+        reservationCount * 0.75,
+        reservationCount * 0.8,
+        reservationCount * 0.85,
+        reservationCount * 0.95,
+        reservationCount,
+      ],
+      max: maxValue * 1.2,
+      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      mainValue: reservationCount,
+      subValues: [reservationCount - cancelledCount, cancelledCount],
+    };
+  } else if (activeTab === '매니저별점' && stats) {
+    const avgRating = Number(stats.avgRating) || 4.0;
+    const reviewCount = Number(stats.reviewCount) || 100;
+    const maxValue = Math.max(avgRating, 5);
+
+    return {
+      values: [
+        avgRating * 0.7,
+        avgRating * 0.75,
+        avgRating * 0.8,
+        avgRating * 0.85,
+        avgRating * 0.9,
+        avgRating * 0.95,
+        avgRating * 0.98,
+        avgRating,
+      ],
+      max: maxValue * 1.2,
+      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      mainValue: avgRating,
+      subValues: [reviewCount],
+    };
+  } else if (activeTab === '매칭' && stats) {
+    const totalCount = Number(stats.totalCount) || 100;
+    const successCount = Number(stats.successCount) || 0;
+    const maxValue = Math.max(totalCount, 100);
+
+    return {
+      values: [
+        totalCount * 0.25,
+        totalCount * 0.4,
+        totalCount * 0.55,
+        totalCount * 0.7,
+        totalCount * 0.8,
+        totalCount * 0.9,
+        totalCount * 0.95,
+        totalCount,
+      ],
+      max: maxValue * 1.2,
+      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      mainValue: totalCount,
+      subValues: [successCount, stats.failCount],
+    };
+  }
+
+  return { values: [], max: 100, labels: [] };
+};
+
+/**
+ * 차트 제목 반환 함수
+ * @param {string} activeTab - 활성 탭
+ * @returns {string} 차트 제목
+ */
+export const getChartTitle = (activeTab) => {
+  switch (activeTab) {
+    case '회원현황':
+      return '회원 증가 추이';
+    case '정산':
+      return '정산 처리 추이';
+    case '결제':
+      return '결제 금액 추이';
+    case '예약관리':
+      return '예약 수 추이';
+    case '매니저별점':
+      return '매니저 평점 추이';
+    case '매칭':
+      return '매칭 시도 추이';
+    default:
+      return '통계 추이';
+  }
+};
+
+/**
+ * 분포 제목 반환 함수
+ * @param {string} activeTab - 활성 탭
+ * @returns {string} 분포 제목
+ */
+export const getDistributionTitle = (activeTab) => {
+  switch (activeTab) {
+    case '회원현황':
+      return '회원 분포';
+    case '정산':
+      return '정산 상태 분포';
+    case '결제':
+      return '결제 수단 분포';
+    case '예약관리':
+      return '예약 상태 분포';
+    case '매니저별점':
+      return '평점 분포';
+    case '매칭':
+      return '매칭 결과 분포';
+    default:
+      return '분포';
+  }
+};
+
+/**
+ * 탭 활성화 여부 확인 함수
+ * @param {string} tabName - 탭 이름
+ * @returns {boolean} 활성화 여부
+ */
+export const isTabEnabled = (tabName) => {
+  const enabledTabs = [
+    '전체',
+    '회원현황',
+    '정산',
+    '결제',
+    '예약관리',
+    '매니저별점',
+    '매칭',
+  ];
+  return enabledTabs.includes(tabName);
+};
+
+/**
+ * 상수 정의
+ */
+export const CONSTANTS = {
+  YEARS: [2023, 2024, 2025],
+  MONTHS: Array.from({ length: 12 }, (_, i) => i + 1),
+  DAYS: Array.from({ length: 31 }, (_, i) => i + 1),
+  MAIN_TABS: [
+    '전체 통계',
+    '회원현황 통계',
+    '정산 통계',
+    '결제 통계',
+    '예약관리 통계',
+    '매니저별점 통계',
+    '매칭 통계',
+  ],
+};

--- a/src/features/admin/utils/statisticsUtils.js
+++ b/src/features/admin/utils/statisticsUtils.js
@@ -60,12 +60,77 @@ export const generateChartPath = (values, max) => {
 };
 
 /**
+ * 해당 년도/월의 일수를 반환하는 함수
+ * @param {number} year - 연도
+ * @param {number} month - 월 (1-12)
+ * @returns {number} 해당 월의 일수
+ */
+export const getDaysInMonth = (year, month) => {
+  return new Date(year, month, 0).getDate();
+};
+
+/**
+ * 선택된 월의 일별 라벨을 생성하는 함수
+ * @param {number} year - 선택된 연도
+ * @param {number} month - 선택된 월 (1-12)
+ * @returns {string[]} 일별 라벨 배열
+ */
+export const generateDailyLabels = (year, month) => {
+  if (!month) {
+    // 월이 선택되지 않은 경우 월별 라벨 반환
+    return [
+      '1월',
+      '2월',
+      '3월',
+      '4월',
+      '5월',
+      '6월',
+      '7월',
+      '8월',
+      '9월',
+      '10월',
+      '11월',
+      '12월',
+    ];
+  }
+
+  const daysInMonth = getDaysInMonth(year, month);
+  return Array.from({ length: daysInMonth }, (_, i) => `${i + 1}일`);
+};
+
+/**
+ * 선택된 월의 일별 더미 데이터를 생성하는 함수
+ * @param {number} baseValue - 기준값
+ * @param {number} daysCount - 일수
+ * @returns {number[]} 일별 더미 데이터 배열
+ */
+export const generateDailyValues = (baseValue, daysCount) => {
+  return Array.from({ length: daysCount }, (_, i) => {
+    // 월 초부터 점진적으로 증가하는 패턴
+    const progress = i / (daysCount - 1);
+    const randomFactor = 0.8 + Math.random() * 0.4; // 0.8~1.2 사이의 랜덤값
+    return Math.round(baseValue * (0.3 + progress * 0.7) * randomFactor);
+  });
+};
+
+/**
  * 차트 데이터 생성 함수
  * @param {string} activeTab - 활성 탭
  * @param {Object} stats - 통계 데이터
+ * @param {number} selectedYear - 선택된 연도
+ * @param {number} selectedMonth - 선택된 월
  * @returns {Object} 차트 데이터
  */
-export const generateChartData = (activeTab, stats) => {
+export const generateChartData = (
+  activeTab,
+  stats,
+  selectedYear,
+  selectedMonth
+) => {
+  // 라벨 생성 (월별 또는 일별)
+  const labels = generateDailyLabels(selectedYear, selectedMonth);
+  const dataCount = labels.length;
+
   if (activeTab === '회원현황' && stats) {
     const totalUsers = Number(stats.totalUsers) || 100;
     const signupCount = Number(stats.signupCount) || 0;
@@ -73,18 +138,9 @@ export const generateChartData = (activeTab, stats) => {
     const maxValue = Math.max(totalUsers, 100);
 
     return {
-      values: [
-        totalUsers * 0.7,
-        totalUsers * 0.75,
-        totalUsers * 0.8,
-        totalUsers * 0.85,
-        totalUsers * 0.9,
-        totalUsers * 0.95,
-        totalUsers,
-        totalUsers,
-      ],
+      values: generateDailyValues(totalUsers, dataCount),
       max: maxValue * 1.2,
-      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      labels,
       mainValue: totalUsers,
       subValues: [signupCount, withdrawCount],
     };
@@ -94,18 +150,9 @@ export const generateChartData = (activeTab, stats) => {
     const maxValue = Math.max(requestedCount, 10);
 
     return {
-      values: [
-        paidCount * 0.3,
-        paidCount * 0.5,
-        paidCount * 0.65,
-        paidCount * 0.75,
-        paidCount * 0.85,
-        paidCount * 0.9,
-        paidCount * 0.95,
-        paidCount,
-      ],
+      values: generateDailyValues(paidCount, dataCount),
       max: maxValue * 1.2,
-      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      labels,
       mainValue: requestedCount,
       subValues: [paidCount, requestedCount - paidCount],
     };
@@ -115,18 +162,9 @@ export const generateChartData = (activeTab, stats) => {
     const maxValue = Math.max(totalAmount, 1000);
 
     return {
-      values: [
-        totalAmount * 0.4,
-        totalAmount * 0.55,
-        totalAmount * 0.7,
-        totalAmount * 0.8,
-        totalAmount * 0.85,
-        totalAmount * 0.9,
-        totalAmount * 0.95,
-        totalAmount,
-      ],
+      values: generateDailyValues(totalAmount, dataCount),
       max: maxValue * 1.2,
-      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      labels,
       mainValue: totalAmount,
       subValues: [totalAmount - cancelAmount, cancelAmount],
     };
@@ -136,18 +174,9 @@ export const generateChartData = (activeTab, stats) => {
     const maxValue = Math.max(reservationCount, 100);
 
     return {
-      values: [
-        reservationCount * 0.3,
-        reservationCount * 0.45,
-        reservationCount * 0.6,
-        reservationCount * 0.75,
-        reservationCount * 0.8,
-        reservationCount * 0.85,
-        reservationCount * 0.95,
-        reservationCount,
-      ],
+      values: generateDailyValues(reservationCount, dataCount),
       max: maxValue * 1.2,
-      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      labels,
       mainValue: reservationCount,
       subValues: [reservationCount - cancelledCount, cancelledCount],
     };
@@ -157,18 +186,9 @@ export const generateChartData = (activeTab, stats) => {
     const maxValue = Math.max(avgRating, 5);
 
     return {
-      values: [
-        avgRating * 0.7,
-        avgRating * 0.75,
-        avgRating * 0.8,
-        avgRating * 0.85,
-        avgRating * 0.9,
-        avgRating * 0.95,
-        avgRating * 0.98,
-        avgRating,
-      ],
+      values: generateDailyValues(avgRating, dataCount),
       max: maxValue * 1.2,
-      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      labels,
       mainValue: avgRating,
       subValues: [reviewCount],
     };
@@ -178,18 +198,9 @@ export const generateChartData = (activeTab, stats) => {
     const maxValue = Math.max(totalCount, 100);
 
     return {
-      values: [
-        totalCount * 0.25,
-        totalCount * 0.4,
-        totalCount * 0.55,
-        totalCount * 0.7,
-        totalCount * 0.8,
-        totalCount * 0.9,
-        totalCount * 0.95,
-        totalCount,
-      ],
+      values: generateDailyValues(totalCount, dataCount),
       max: maxValue * 1.2,
-      labels: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월'],
+      labels,
       mainValue: totalCount,
       subValues: [successCount, stats.failCount],
     };


### PR DESCRIPTION
## 📌 개요
- 관리자용 통계 시스템에서 사용되는 모든 StatisticsProvider 구현체들에 대해 연/월/일 단위로 조건 분기 처리 로직을 적용
- 통계 데이터를 Redis/DB에 안정적으로 저장/조회하기 위한 구조 리팩토링을 수행
- 관리자 대시보드 페이지 매출내역 보이도록 수정
- 결제, 정산 페이지에 환불금액 계산로직 추가

## 🛠️ 변경 사항
-연/월/일 조건 분기 구조가 명확하지 않음
  - 가독성 및 테스트/확장성 부족
- 대시보드에 있는 자잘한 카드들과 하드코딩된 그래프
- 현재 결제, 정산페이지에는 환불 로직이 있지만 데이터에는 반영이 안되어 있음
  - 환불이 된 결제내역도 12만원으로 고정
- 그 외 ui 수정

## ✅ 주요 체크 포인트

- [ ] 리뷰어가 중점적으로 봐야 할 부분이 있다면 적어주세요.
- [ ] 예: validation 처리 방식, 성능 개선 등


## 📑 레퍼런스
#80 
